### PR TITLE
[CRM457-517] Adds change risk event to history

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,7 @@ class Event < ApplicationRecord
 
   self.inheritance_column = :event_type
 
-  HISTORY_EVENTS = ['Event::NewVersion', 'Event::Decision'].freeze
+  HISTORY_EVENTS = ['Event::NewVersion', 'Event::Decision', 'Event::ChangeRisk'].freeze
   scope :history, -> { where(event_type: HISTORY_EVENTS) }
 
   # Make these methods private to ensure tehy are created via the various `build` methods`

--- a/app/models/event/change_risk.rb
+++ b/app/models/event/change_risk.rb
@@ -13,5 +13,9 @@ class Event
         }
       )
     end
+
+    def title_options
+      { risk: details['to'] }
+    end
   end
 end

--- a/config/locales/en/events.yml
+++ b/config/locales/en/events.yml
@@ -4,3 +4,5 @@ en:
     title: New claim versions received
   event/decision:
     title: Decision made to %{state} claim
+  event/change_risk:
+    title: Claim risk changed to %{risk} risk

--- a/spec/models/event/change_risk_spec.rb
+++ b/spec/models/event/change_risk_spec.rb
@@ -23,4 +23,8 @@ RSpec.describe Event::ChangeRisk do
       }
     )
   end
+
+  it 'has a valid title' do
+    expect(subject.title).to eq('Claim risk changed to low risk')
+  end
 end


### PR DESCRIPTION
## Description of change

## Link to relevant ticket

[Change risk: Add event into Claim history (CW)](https://dsdmoj.atlassian.net/browse/CRM457-517)

## Screenshots of changes
![Screenshot 2023-10-11 at 12 27 22](https://github.com/ministryofjustice/laa-assess-non-standard-magistrate-fee/assets/90189839/6af8c124-52f4-4d81-8a66-ae58d9ef19af)
