### PR TITLE
CRM457-511 - Ensure we are using the correct error messaging

### DIFF
--- a/app/controllers/change_risks_controller.rb
+++ b/app/controllers/change_risks_controller.rb
@@ -1,7 +1,7 @@
 class ChangeRisksController < ApplicationController
   def edit
     claim = Claim.find(params[:claim_id])
-    risk = ChangeRiskForm.new(id: params[:claim_id])
+    risk = ChangeRiskForm.new(id: params[:claim_id], risk_level: claim.risk)
     render locals: { claim:, risk: }
   end
 

--- a/app/forms/change_risk_form.rb
+++ b/app/forms/change_risk_form.rb
@@ -29,7 +29,7 @@ class ChangeRiskForm
     end
 
     true
-  rescue StandardError => e
+  rescue StandardError
     false
   end
 

--- a/app/views/change_risks/edit.html.erb
+++ b/app/views/change_risks/edit.html.erb
@@ -5,6 +5,7 @@
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
     <p class="govuk-body"> <%= t('.current_risk', level: claim.risk) %></p>
     <%= form_with model: risk, url:edit_claim_change_risk_path(claim.id),method: :put do |f| %>
+      <%= govuk_error_summary(risk) %>
       <%= f.govuk_collection_radio_buttons :risk_level, risk.available_risks, :id, :level, legend: { text: t('.legend') } %>
       <%= f.govuk_text_area :explanation, label: { text: t('.text_area.label'), size: 'm' }, hint: { text: t('.text_area.hint') }, rows: 5 %>
       <%= f.govuk_submit t('shared.save_changes') do %>

--- a/config/locales/en/change_risks.yml
+++ b/config/locales/en/change_risks.yml
@@ -20,7 +20,7 @@ en:
             risk_level:
               blank: Select what you want to change the risk to
               inclusion: Select what you want to change the risk to
-              unchanged: You haven't changed the risk
+              unchanged: You have not changed the risk, select the risk you want to change to
             explanation:
               blank: Explain why you are changing the risk
 

--- a/config/locales/en/change_risks.yml
+++ b/config/locales/en/change_risks.yml
@@ -11,3 +11,17 @@ en:
         hint: This information is for LAA only. It will not be shared with the provider.
     update:
       success: You changed the claim risk to %{level}
+
+  activemodel:
+    errors:
+      models:
+        change_risk_form:
+          attributes:
+            risk_level:
+              blank: Select what you want to change the risk to
+              inclusion: Select what you want to change the risk to
+              unchanged: You haven't changed the risk
+            explanation:
+              blank: Explain why you are changing the risk
+
+

--- a/config/locales/en/make_decisions.yml
+++ b/config/locales/en/make_decisions.yml
@@ -33,9 +33,9 @@ en:
         make_decision_form:
           attributes:
             state:
-              blank: Please select a decision
-              inclusion: Please select a decision
+              blank: Select what you want to do with this claim
+              inclusion: Select what you want to do with this claim
             partial_comment:
-              blank: Reason must be given to part grant
+              blank: Add an explanation for your decision
             reject_comment:
-              blank: Reason must be given to reject
+              blank: Add an explanation for your decision

--- a/spec/controllers/change_risks_controller_spec.rb
+++ b/spec/controllers/change_risks_controller_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ChangeRisksController, type: :controller do
   context 'edit' do
-    let(:claim) { instance_double(Claim, id: claim_id) }
+    let(:claim) { instance_double(Claim, id: claim_id, risk: 'high') }
     let(:claim_id) { SecureRandom.uuid }
     let(:risk) { instance_double(ChangeRiskForm) }
 

--- a/spec/forms/change_risk_form_spec.rb
+++ b/spec/forms/change_risk_form_spec.rb
@@ -22,10 +22,66 @@ RSpec.describe ChangeRiskForm, type: :model do
     end
   end
 
+  describe '#validations' do
+    subject { described_class.new(id:, risk_level:, explanation:) }
+    let(:id) { claim.id }
+    let(:risk_level) { 'high' }
+    let(:explanation) { 'changed to high' }
+
+    context 'risk_level' do
+      %w[high medium].each do |valid_risk|
+        context "when risk is #{valid_risk}" do
+          let(:risk_level) { valid_risk }
+
+          it { expect(subject).to be_valid }
+        end
+      end
+
+      context 'when risk level is unchanged' do
+        let(:risk_level) { 'low' }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:risk_level, :unchanged)).to be(true)
+        end
+      end
+
+      context 'when risk level is something else' do
+        let(:risk_level) { 'other' }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:risk_level, :inclusion)).to be(true)
+        end
+      end
+    end
+
+    describe 'explanation' do
+      context 'when it is blank' do
+        let(:explanation) { '' }
+
+        it 'is invalid' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:explanation, :blank)).to be(true)
+        end
+
+        context 'but the risk level has not changed' do
+          let(:risk_level) { 'low' }
+
+          it 'is does not raise an error' do
+            expect(subject).not_to be_valid
+            expect(subject.errors.of_kind?(:explanation, :blank)).to be(false)
+          end
+        end
+      end
+    end
+  end
+
   describe '#save' do
     subject { described_class.new(params) }
 
-    let(:params) { { id: claim.id, risk_level: 'low', explanation: 'Test', current_user: user } }
+    let(:params) { { id: claim.id, risk_level: risk_level, explanation: 'Test', current_user: user } }
+    let(:risk_level) { 'high' }
 
     before do
       allow(Event::ChangeRisk).to receive(:build)
@@ -33,7 +89,7 @@ RSpec.describe ChangeRiskForm, type: :model do
 
     it 'updates the claim' do
       subject.save
-      expect(claim.reload).to have_attributes(risk: 'low')
+      expect(claim.reload).to have_attributes(risk: 'high')
     end
 
     context 'when not valid' do

--- a/spec/forms/change_risk_form_spec.rb
+++ b/spec/forms/change_risk_form_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe ChangeRiskForm, type: :model do
 
   describe '#validations' do
     subject { described_class.new(id:, risk_level:, explanation:) }
+
     let(:id) { claim.id }
     let(:risk_level) { 'high' }
     let(:explanation) { 'changed to high' }


### PR DESCRIPTION
## Description of change
set correct error messages for make decision screen

## Link to relevant ticket
[CRM457-511](https://dsdmoj.atlassian.net/browse/CRM457-511)



[CRM457-511]: https://dsdmoj.atlassian.net/browse/CRM457-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<img width="671" alt="Screenshot 2023-10-13 at 11 15 23" src="https://github.com/ministryofjustice/laa-assess-non-standard-magistrate-fee/assets/63736/e639966c-2a4e-40aa-a8d7-f5f84ec83505">
<img width="686" alt="Screenshot 2023-10-13 at 11 15 33" src="https://github.com/ministryofjustice/laa-assess-non-standard-magistrate-fee/assets/63736/d9b02891-607f-4cf3-ae01-65a720dbb7e3">
