### PR TITLE
Crm457 621/event refactor 2

### DIFF
--- a/app/controllers/disbursements_controller.rb
+++ b/app/controllers/disbursements_controller.rb
@@ -3,7 +3,7 @@ class DisbursementsController < ApplicationController
 
   def index
     claim = Claim.find(params[:claim_id])
-    disbursements = BaseViewModel.build_all(:disbursement, claim, 'disbursements').group_by(&:disbursement_date)
+    disbursements = BaseViewModel.build(:disbursement, claim, 'disbursements').group_by(&:disbursement_date)
 
     render locals: { claim:, disbursements: }
   end

--- a/app/controllers/letters_and_calls_controller.rb
+++ b/app/controllers/letters_and_calls_controller.rb
@@ -10,7 +10,7 @@ class LettersAndCallsController < ApplicationController
 
   def edit
     claim = Claim.find(params[:claim_id])
-    item = BaseViewModel.build_all(:letter_and_call, claim, 'letters_and_calls').detect do |model|
+    item = BaseViewModel.build(:letter_and_call, claim, 'letters_and_calls').detect do |model|
       model.type.value == params[:id]
     end
     form = LettersCallsForm.new(id: claim.id, **item.form_attributes)
@@ -20,7 +20,7 @@ class LettersAndCallsController < ApplicationController
 
   def update
     claim = Claim.find(params[:claim_id])
-    item = BaseViewModel.build_all(:letter_and_call, claim, 'letters_and_calls').detect do |model|
+    item = BaseViewModel.build(:letter_and_call, claim, 'letters_and_calls').detect do |model|
       model.type.value == params[:id]
     end
     form = LettersCallsForm.new(item:, **form_params)

--- a/app/controllers/supporting_evidences_controller.rb
+++ b/app/controllers/supporting_evidences_controller.rb
@@ -2,7 +2,7 @@ class SupportingEvidencesController < ApplicationController
   def show
     claim = Claim.find(params[:claim_id])
     claim_summary = BaseViewModel.build(:claim_summary, claim)
-    supporting_evidence = BaseViewModel.build_all(:supporting_evidence, claim, 'supporting_evidences')
+    supporting_evidence = BaseViewModel.build(:supporting_evidence, claim, 'supporting_evidences')
 
     @pagy, @supporting_evidence = pagy_array(supporting_evidence)
     render locals: { claim:, claim_summary: }

--- a/app/controllers/work_items_controller.rb
+++ b/app/controllers/work_items_controller.rb
@@ -3,7 +3,7 @@ class WorkItemsController < ApplicationController
 
   def index
     claim = Claim.find(params[:claim_id])
-    work_items = BaseViewModel.build_all(:work_item, claim, 'work_items').group_by(&:completed_on)
+    work_items = BaseViewModel.build(:work_item, claim, 'work_items').group_by(&:completed_on)
     travel_and_waiting = BaseViewModel.build(:travel_and_waiting, claim)
 
     render locals: { claim:, work_items:, travel_and_waiting: }

--- a/app/view_models/base_view_model.rb
+++ b/app/view_models/base_view_model.rb
@@ -2,53 +2,60 @@ class BaseViewModel
   include ActiveModel::Model
   include ActiveModel::Attributes
 
-  class << self
-    def build(class_type, claim, *nesting)
-      klass = "V#{claim.json_schema_version}::#{class_type.to_s.camelcase}".constantize
+  class Builder
+    attr_reader :klass, :claim, :rows, :return_array
 
-      attributes = claim.attributes.merge(claim.data, 'claim' => claim)
-      attributes = attributes.dig(*nesting) if nesting.any?
-
-      klass.new(attributes.slice(*klass.attribute_names))
-    end
-
-    def build_all(class_type, claim, *)
-      klass = "V#{claim.json_schema_version}::#{class_type.to_s.camelcase}".constantize
-
-      rows = claim.data[*]
-
-      klass.build_from_hash(rows, claim)
-    end
-
-    def build_from_hash(rows, claim)
-      raise 'can not be called on BaseViewModel' if self == BaseViewModel
-
-      if const_defined?(:LINKED_TYPE)
-        all_adjustments = all_adjustments(claim, rows)
-
-        rows.map do |attributes|
-          key = [attributes.dig('type', 'value') || self::LINKED_TYPE, attributes['id']]
-          adjustments = all_adjustments.fetch(key, [])
-          new(adjustments:, **attributes.slice(*attribute_names))
-        end
+    def initialize(class_type, claim, *nesting)
+      @klass = "V#{claim.json_schema_version}::#{class_type.to_s.camelcase}".constantize
+      @claim = claim
+      if nesting.any?
+        @rows = claim.data.dig(*nesting)
+        @return_array = true
       else
-        rows.map { |attributes| build_self(attributes) }
+        @rows = [claim.data]
+        @return_array = false
       end
     end
 
-    def build_self(attributes)
-      new(attributes.slice(*attribute_names))
+    def build
+      process do |attributes|
+        data = attributes.slice(*klass.attribute_names)
+
+        if klass.const_defined?(:LINKED_TYPE)
+          key = [attributes.dig('type', 'value') || klass::LINKED_TYPE, attributes['id']]
+          data.merge!(adjustments: all_adjustments.fetch(key, []))
+        end
+
+        klass.new(data)
+      end
     end
 
     private
 
-    def all_adjustments(claim, rows)
-      linked_ids = rows.pluck('id')
+    def process(&block)
+      result = rows.map(&block)
+      return_array ? result : result[0]
+    end
 
-      claim.events
-           .where(linked_type: self::LINKED_TYPE, linked_id: linked_ids)
-           .order(:created_at)
-           .group_by { |event| [event.linked_type, event.linked_id] }
+    def all_adjustments
+      @all_adjustments ||= begin
+        linked_ids = rows.pluck('id')
+
+        claim.events
+            .where(linked_type: klass::LINKED_TYPE, linked_id: linked_ids)
+            .order(:created_at)
+            .group_by { |event| [event.linked_type, event.linked_id] }
+      end
+    end
+  end
+
+  class << self
+    def build(class_type, claim)
+      Builder.new(class_type, claim).build
+    end
+
+    def build(class_type, claim, *)
+      Builder.new(class_type, claim, *).build
     end
   end
 

--- a/app/view_models/base_view_model.rb
+++ b/app/view_models/base_view_model.rb
@@ -19,9 +19,11 @@ class BaseViewModel
 
     def build
       process do |attributes|
-        data = attributes.slice(*klass.attribute_names)
+        data = claim.attributes
+                    .merge(attributes, 'claim' => claim)
+                    .slice(*klass.attribute_names)
 
-        if klass.const_defined?(:LINKED_TYPE)
+        if adjustments?
           key = [attributes.dig('type', 'value') || klass::LINKED_TYPE, attributes['id']]
           data[:adjustments] = all_adjustments.fetch(key, [])
         end
@@ -46,6 +48,10 @@ class BaseViewModel
              .order(:created_at)
              .group_by { |event| [event.linked_type, event.linked_id] }
       end
+    end
+
+    def adjustments?
+      klass.const_defined?(:LINKED_TYPE)
     end
   end
 

--- a/app/view_models/base_view_model.rb
+++ b/app/view_models/base_view_model.rb
@@ -23,7 +23,7 @@ class BaseViewModel
 
         if klass.const_defined?(:LINKED_TYPE)
           key = [attributes.dig('type', 'value') || klass::LINKED_TYPE, attributes['id']]
-          data.merge!(adjustments: all_adjustments.fetch(key, []))
+          data[:adjustments] = all_adjustments.fetch(key, [])
         end
 
         klass.new(data)
@@ -42,18 +42,14 @@ class BaseViewModel
         linked_ids = rows.pluck('id')
 
         claim.events
-            .where(linked_type: klass::LINKED_TYPE, linked_id: linked_ids)
-            .order(:created_at)
-            .group_by { |event| [event.linked_type, event.linked_id] }
+             .where(linked_type: klass::LINKED_TYPE, linked_id: linked_ids)
+             .order(:created_at)
+             .group_by { |event| [event.linked_type, event.linked_id] }
       end
     end
   end
 
   class << self
-    def build(class_type, claim)
-      Builder.new(class_type, claim).build
-    end
-
     def build(class_type, claim, *)
       Builder.new(class_type, claim, *).build
     end

--- a/app/view_models/shared/work_item_summary.rb
+++ b/app/view_models/shared/work_item_summary.rb
@@ -18,8 +18,8 @@ module Shared
     private
 
     def grouped_work_items
-      work_items.map { |work_item| class_scope::WorkItem.build_self(work_item) }
-                .group_by { |work_item| work_item.work_type.to_s }
+      BaseViewModel.build(:work_item, claim, 'work_items')
+                   .group_by { |work_item| work_item.work_type.to_s }
     end
 
     # overwrite if you need custom filtering
@@ -28,9 +28,5 @@ module Shared
       false
     end
     # :nocov:
-
-    def class_scope
-      @class_scope ||= self.class.module_parent
-    end
   end
 end

--- a/app/view_models/v1/core_cost_summary.rb
+++ b/app/view_models/v1/core_cost_summary.rb
@@ -4,8 +4,6 @@ module V1
 
     SKIPPED_TYPES = %w[travel waiting].freeze
 
-    attribute :work_items
-    attribute :letters_and_calls
     attribute :claim
 
     def table_fields
@@ -37,7 +35,7 @@ module V1
     end
 
     def letter_and_call_data
-      rows = LettersAndCallsSummary.build_self('claim' => claim, 'letters_and_calls' => letters_and_calls).rows
+      rows = LettersAndCallsSummary.new('claim' => claim).rows
       rows.filter_map do |letter_or_call|
         next if letter_or_call.provider_requested_count.zero?
 

--- a/app/view_models/v1/letters_and_calls_summary.rb
+++ b/app/view_models/v1/letters_and_calls_summary.rb
@@ -1,6 +1,5 @@
 module V1
   class LettersAndCallsSummary < BaseViewModel
-    attribute :letters_and_calls
     attribute :claim
 
     def summary_row
@@ -14,7 +13,7 @@ module V1
     end
 
     def rows
-      @rows ||= LetterAndCall.build_from_hash(letters_and_calls, claim)
+      @rows ||= BaseViewModel.build(:letter_and_call, claim, 'letters_and_calls')
     end
   end
 end

--- a/app/view_models/v1/travel_and_waiting.rb
+++ b/app/view_models/v1/travel_and_waiting.rb
@@ -4,7 +4,7 @@ module V1
 
     INCLUDED_TYPES = %w[travel waiting].freeze
 
-    attribute :work_items
+    attribute :claim
 
     def table_fields
       work_item_data.map do |work_type, total_cost, total_time_spent|

--- a/spec/controllers/disbursements_controller_spec.rb
+++ b/spec/controllers/disbursements_controller_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe DisbursementsController do
 
     before do
       allow(Claim).to receive(:find).and_return(claim)
-      allow(BaseViewModel).to receive_messages(build_all: disbursements)
+      allow(BaseViewModel).to receive_messages(build: disbursements)
     end
 
     it 'find and builds the required object' do
       get :index, params: { claim_id: }
 
       expect(Claim).to have_received(:find).with(claim_id)
-      expect(BaseViewModel).to have_received(:build_all).with(:disbursement, claim, 'disbursements')
+      expect(BaseViewModel).to have_received(:build).with(:disbursement, claim, 'disbursements')
     end
 
     it 'renders successfully with claims' do

--- a/spec/controllers/letters_and_calls_controller_spec.rb
+++ b/spec/controllers/letters_and_calls_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe LettersAndCallsController do
 
     before do
       allow(Claim).to receive(:find).and_return(claim)
-      allow(BaseViewModel).to receive(:build_all).and_return(letters_and_calls)
+      allow(BaseViewModel).to receive(:build).and_return(letters_and_calls)
       allow(LettersCallsForm).to receive(:new).and_return(form)
     end
 
@@ -74,7 +74,7 @@ RSpec.describe LettersAndCallsController do
     let(:letters) { instance_double(V1::LetterAndCall, type: double(value: 'letters'), form_attributes: {}) }
 
     before do
-      allow(BaseViewModel).to receive(:build_all).and_return(letters_and_calls)
+      allow(BaseViewModel).to receive(:build).and_return(letters_and_calls)
       allow(LettersCallsForm).to receive(:new).and_return(form)
       allow(Claim).to receive(:find).and_return(claim)
     end

--- a/spec/controllers/supporting_evidences_controller_spec.rb
+++ b/spec/controllers/supporting_evidences_controller_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe SupportingEvidencesController do
 
     before do
       allow(Claim).to receive(:find).and_return(claim)
-      allow(BaseViewModel).to receive_messages(build: claim_summary)
-      allow(BaseViewModel).to receive_messages(build: supporting_evidence)
+      allow(BaseViewModel).to receive(:build).with(:claim_summary, anything).and_return(claim_summary)
+      allow(BaseViewModel).to receive(:build).with(:supporting_evidence, anything, anything).and_return(supporting_evidence)
     end
 
     it 'find and builds the required object' do

--- a/spec/controllers/supporting_evidences_controller_spec.rb
+++ b/spec/controllers/supporting_evidences_controller_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe SupportingEvidencesController do
     before do
       allow(Claim).to receive(:find).and_return(claim)
       allow(BaseViewModel).to receive(:build).with(:claim_summary, anything).and_return(claim_summary)
-      allow(BaseViewModel).to receive(:build).with(:supporting_evidence, anything, anything).and_return(supporting_evidence)
+      allow(BaseViewModel).to receive(:build).with(:supporting_evidence, anything,
+                                                   anything).and_return(supporting_evidence)
     end
 
     it 'find and builds the required object' do

--- a/spec/controllers/supporting_evidences_controller_spec.rb
+++ b/spec/controllers/supporting_evidences_controller_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe SupportingEvidencesController do
     before do
       allow(Claim).to receive(:find).and_return(claim)
       allow(BaseViewModel).to receive_messages(build: claim_summary)
-      allow(BaseViewModel).to receive_messages(build_all: supporting_evidence)
+      allow(BaseViewModel).to receive_messages(build: supporting_evidence)
     end
 
     it 'find and builds the required object' do
       get :show, params: { claim_id: }
 
       expect(Claim).to have_received(:find).with(claim_id)
-      expect(BaseViewModel).to have_received(:build_all).with(:supporting_evidence, claim, 'supporting_evidences')
+      expect(BaseViewModel).to have_received(:build).with(:supporting_evidence, claim, 'supporting_evidences')
     end
 
     it 'renders successfully with claims' do

--- a/spec/controllers/work_items_controller_spec.rb
+++ b/spec/controllers/work_items_controller_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe WorkItemsController do
 
     before do
       allow(Claim).to receive(:find).and_return(claim)
-      allow(BaseViewModel).to receive_messages(build: work_items)
-      allow(BaseViewModel).to receive_messages(build: travel_and_waiting)
+      allow(BaseViewModel).to receive(:build).with(:work_item, anything, anything).and_return(work_items)
+      allow(BaseViewModel).to receive(:build).with(:travel_and_waiting, anything).and_return(travel_and_waiting)
     end
 
     it 'find and builds the required object' do

--- a/spec/controllers/work_items_controller_spec.rb
+++ b/spec/controllers/work_items_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe WorkItemsController do
 
     before do
       allow(Claim).to receive(:find).and_return(claim)
-      allow(BaseViewModel).to receive_messages(build_all: work_items)
+      allow(BaseViewModel).to receive_messages(build: work_items)
       allow(BaseViewModel).to receive_messages(build: travel_and_waiting)
     end
 
@@ -18,7 +18,7 @@ RSpec.describe WorkItemsController do
       get :index, params: { claim_id: }
 
       expect(Claim).to have_received(:find).with(claim_id)
-      expect(BaseViewModel).to have_received(:build_all).with(:work_item, claim, 'work_items')
+      expect(BaseViewModel).to have_received(:build).with(:work_item, claim, 'work_items')
       expect(BaseViewModel).to have_received(:build).with(:travel_and_waiting, claim)
     end
 

--- a/spec/view_models/base_view_model_spec.rb
+++ b/spec/view_models/base_view_model_spec.rb
@@ -22,26 +22,15 @@ RSpec.describe BaseViewModel do
         defendants: [{ 'some' => 'data' }]
       )
     end
-
-    context 'when using nesting' do
-      let(:data) do
-        { 'work_items' => [{ 'work_type' => { 'value' => 'first' } }, { 'work_type' => { 'value' => 'second' } }] }
-      end
-
-      it 'builds the object from the hash of attributes specified by the nested location' do
-        work_item = described_class.build(:work_item, claim, 'work_items', 1)
-        expect(work_item).to have_attributes(work_type: TranslationObject.new('value' => 'second'))
-      end
-    end
   end
 
-  describe '#build_all' do
+  describe '#build' do
     let(:data) do
       { 'work_items' => [{ 'work_type' => { 'value' => 'first' } }, { 'work_type' => { 'value' => 'second' } }] }
     end
 
     it 'builds the object from the array of hashes of attributes' do
-      work_items = described_class.build_all(:work_item, claim, 'work_items')
+      work_items = described_class.build(:work_item, claim, 'work_items')
       expect(work_items.count).to eq(2)
       expect(work_items[0]).to have_attributes(work_type: TranslationObject.new('value' => 'first'))
       expect(work_items[1]).to have_attributes(work_type: TranslationObject.new('value' => 'second'))
@@ -55,20 +44,10 @@ RSpec.describe BaseViewModel do
       end
 
       it 'correctly applies adjustments' do
-        letters, calls = *described_class.build_all(:letter_and_call, claim, 'letters_and_calls')
+        letters, calls = *described_class.build(:letter_and_call, claim, 'letters_and_calls')
         expect(letters.adjustments).to eq(claim.events)
         expect(calls.adjustments).to eq([])
       end
-    end
-  end
-
-  describe '#build_from_hash' do
-    let(:rows) { [] }
-    let(:claim) { instance_double(Claim) }
-
-    it 'can not be called on the base model' do
-      expect { described_class.build_from_hash(rows, claim) }.to raise_error('can not be called on BaseViewModel')
-      expect { implementation_class.build_from_hash(rows, claim) }.not_to raise_error
     end
   end
 end

--- a/spec/view_models/base_view_model_spec.rb
+++ b/spec/view_models/base_view_model_spec.rb
@@ -6,47 +6,49 @@ RSpec.describe BaseViewModel do
   let(:state) { 'grant' }
 
   describe '#build' do
-    let(:data) { { 'laa_reference' => 'LA111', 'defendants' => [{ 'some' => 'data' }], 'state' => 'grant' } }
+    context 'for a single object' do
+      let(:data) { { 'laa_reference' => 'LA111', 'defendants' => [{ 'some' => 'data' }], 'state' => 'grant' } }
 
-    it 'returns an instance with the correct attributes' do
-      result = described_class.build(:assessed_claims, claim)
-      expect(result).to have_attributes(
-        state: 'grant',
-      )
-    end
-
-    it 'builds the object from the hash of attributes' do
-      summary = described_class.build(:claim_summary, claim)
-      expect(summary).to have_attributes(
-        laa_reference: 'LA111',
-        defendants: [{ 'some' => 'data' }]
-      )
-    end
-  end
-
-  describe '#build' do
-    let(:data) do
-      { 'work_items' => [{ 'work_type' => { 'value' => 'first' } }, { 'work_type' => { 'value' => 'second' } }] }
-    end
-
-    it 'builds the object from the array of hashes of attributes' do
-      work_items = described_class.build(:work_item, claim, 'work_items')
-      expect(work_items.count).to eq(2)
-      expect(work_items[0]).to have_attributes(work_type: TranslationObject.new('value' => 'first'))
-      expect(work_items[1]).to have_attributes(work_type: TranslationObject.new('value' => 'second'))
-    end
-
-    context 'when adjustments exist' do
-      let(:claim) do
-        create(:claim).tap do |claim|
-          create(:event, :edit_count, claim:)
-        end
+      it 'returns an instance with the correct attributes' do
+        result = described_class.build(:assessed_claims, claim)
+        expect(result).to have_attributes(
+          state: 'grant',
+        )
       end
 
-      it 'correctly applies adjustments' do
-        letters, calls = *described_class.build(:letter_and_call, claim, 'letters_and_calls')
-        expect(letters.adjustments).to eq(claim.events)
-        expect(calls.adjustments).to eq([])
+      it 'builds the object from the hash of attributes' do
+        summary = described_class.build(:claim_summary, claim)
+        expect(summary).to have_attributes(
+          laa_reference: 'LA111',
+          defendants: [{ 'some' => 'data' }]
+        )
+      end
+    end
+
+    context 'for a nested object' do
+      let(:data) do
+        { 'work_items' => [{ 'work_type' => { 'value' => 'first' } }, { 'work_type' => { 'value' => 'second' } }] }
+      end
+
+      it 'builds the object from the array of hashes of attributes' do
+        work_items = described_class.build(:work_item, claim, 'work_items')
+        expect(work_items.count).to eq(2)
+        expect(work_items[0]).to have_attributes(work_type: TranslationObject.new('value' => 'first'))
+        expect(work_items[1]).to have_attributes(work_type: TranslationObject.new('value' => 'second'))
+      end
+
+      context 'when adjustments exist' do
+        let(:claim) do
+          create(:claim).tap do |claim|
+            create(:event, :edit_count, claim:)
+          end
+        end
+
+        it 'correctly applies adjustments' do
+          letters, calls = *described_class.build(:letter_and_call, claim, 'letters_and_calls')
+          expect(letters.adjustments).to eq(claim.events)
+          expect(calls.adjustments).to eq([])
+        end
       end
     end
   end

--- a/spec/view_models/v1/core_cost_summary_spec.rb
+++ b/spec/view_models/v1/core_cost_summary_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe V1::CoreCostSummary do
-  subject { described_class.new(work_items:, letters_and_calls:, claim:) }
+  subject { described_class.new(claim:) }
 
   before do
     allow(CostCalculator).to receive(:cost).and_return(100.0)
   end
 
-  let(:claim) { Claim.new }
+  let(:claim) { build(:claim).tap { |claim| claim.data.merge!('letters_and_calls' => letters_and_calls, 'work_items' => work_items)} }
   let(:letters_and_calls) do
     [
       { 'type' => { 'en' => 'Letters' }, 'count' => 10, 'pricing' => 4.04 },
@@ -21,7 +21,8 @@ RSpec.describe V1::CoreCostSummary do
       let(:work_item) { instance_double(V1::WorkItem, work_type: mock_translated('advocacy'), time_spent: 20) }
 
       before do
-        allow(V1::WorkItem).to receive(:build_self).and_return(work_item)
+        allow(BaseViewModel).to receive(:build).and_call_original
+        allow(BaseViewModel).to receive(:build).with(:work_item, anything, anything).and_return([work_item])
       end
 
       it 'includes the letters and calls rows' do
@@ -43,9 +44,8 @@ RSpec.describe V1::CoreCostSummary do
 
       it 'builds the view model' do
         subject.summed_fields
-        expect(V1::WorkItem).to have_received(:build_self).with(
-          'work_type' => { 'en' => 'advocacy', 'value' => 'advocacy' },
-          'time_spent' => 20
+        expect(BaseViewModel).to have_received(:build).with(
+          :work_item, claim, 'work_items'
         )
       end
 
@@ -101,14 +101,14 @@ RSpec.describe V1::CoreCostSummary do
       let(:work_item) { instance_double(V1::WorkItem, work_type: mock_translated('advocacy'), time_spent: 20) }
 
       before do
-        allow(V1::WorkItem).to receive(:build_self).and_return(work_item)
+        allow(BaseViewModel).to receive(:build).and_call_original
+        allow(BaseViewModel).to receive(:build).with(:work_item, anything, anything).and_return([work_item])
       end
 
       it 'builds a WorkType record to use in the calculations' do
         subject.summed_fields
-        expect(V1::WorkItem).to have_received(:build_self).with(
-          'work_type' => { 'en' => 'advocacy', 'value' => 'advocacy' },
-          'time_spent' => 20
+        expect(BaseViewModel).to have_received(:build).with(
+          :work_item, claim, 'work_items'
         )
       end
 

--- a/spec/view_models/v1/core_cost_summary_spec.rb
+++ b/spec/view_models/v1/core_cost_summary_spec.rb
@@ -7,7 +7,11 @@ RSpec.describe V1::CoreCostSummary do
     allow(CostCalculator).to receive(:cost).and_return(100.0)
   end
 
-  let(:claim) { build(:claim).tap { |claim| claim.data.merge!('letters_and_calls' => letters_and_calls, 'work_items' => work_items)} }
+  let(:claim) do
+    build(:claim).tap do |claim|
+      claim.data.merge!('letters_and_calls' => letters_and_calls, 'work_items' => work_items)
+    end
+  end
   let(:letters_and_calls) do
     [
       { 'type' => { 'en' => 'Letters' }, 'count' => 10, 'pricing' => 4.04 },

--- a/spec/view_models/v1/letters_and_calls_summary_spec.rb
+++ b/spec/view_models/v1/letters_and_calls_summary_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe V1::LettersAndCallsSummary, type: :model do
   let(:letters_and_calls) do
     [{ 'type' => { 'en' => 'Letters', 'value' => 'letters' }, 'count' => 12, 'uplift' => 0, 'pricing' => 3.56 }]
   end
-  let(:claim) { Claim.new }
-  let(:letters_and_calls_summary) { described_class.new(letters_and_calls:, claim:) }
+  let(:claim) { build(:claim).tap { |claim| claim.data.merge!('letters_and_calls' => letters_and_calls)} }
+  let(:letters_and_calls_summary) { described_class.new(claim:) }
 
   describe '#summary_row' do
     it 'returns an array of summary row fields' do

--- a/spec/view_models/v1/letters_and_calls_summary_spec.rb
+++ b/spec/view_models/v1/letters_and_calls_summary_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe V1::LettersAndCallsSummary, type: :model do
   let(:letters_and_calls) do
     [{ 'type' => { 'en' => 'Letters', 'value' => 'letters' }, 'count' => 12, 'uplift' => 0, 'pricing' => 3.56 }]
   end
-  let(:claim) { build(:claim).tap { |claim| claim.data.merge!('letters_and_calls' => letters_and_calls)} }
+  let(:claim) { build(:claim).tap { |claim| claim.data.merge!('letters_and_calls' => letters_and_calls) } }
   let(:letters_and_calls_summary) { described_class.new(claim:) }
 
   describe '#summary_row' do

--- a/spec/view_models/v1/travel_and_waiting_spec.rb
+++ b/spec/view_models/v1/travel_and_waiting_spec.rb
@@ -1,7 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe V1::TravelAndWaiting do
-  subject { described_class.new(work_items:) }
+  subject { described_class.new(claim:) }
+  let(:claim) { build(:claim).tap { |claim| claim.data.merge!('work_items' => work_items)} }
 
   before do
     allow(CostCalculator).to receive(:cost).and_return(100.0)
@@ -13,14 +14,13 @@ RSpec.describe V1::TravelAndWaiting do
       let(:work_item) { instance_double(V1::WorkItem, work_type: mock_translated('travel'), time_spent: 20) }
 
       before do
-        allow(V1::WorkItem).to receive(:build_self).and_return(work_item)
+        allow(BaseViewModel).to receive(:build).and_return([work_item])
       end
 
       it 'builds the view model' do
         subject.table_fields
-        expect(V1::WorkItem).to have_received(:build_self).with(
-          'work_type' => { 'en' => 'travel', 'value' => 'travel' },
-          'time_spent' => 20
+        expect(BaseViewModel).to have_received(:build).with(
+          :work_item, claim, 'work_items'
         )
       end
 

--- a/spec/view_models/v1/travel_and_waiting_spec.rb
+++ b/spec/view_models/v1/travel_and_waiting_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe V1::TravelAndWaiting do
   subject { described_class.new(claim:) }
-  let(:claim) { build(:claim).tap { |claim| claim.data.merge!('work_items' => work_items)} }
+
+  let(:claim) { build(:claim).tap { |claim| claim.data.merge!('work_items' => work_items) } }
 
   before do
     allow(CostCalculator).to receive(:cost).and_return(100.0)


### PR DESCRIPTION
## Description of change
Only a single way to build view models

This reduces the number of ways we do things.. which hopefully means stuff will be simplier

## Link to relevant ticket

[CRM457-621](https://dsdmoj.atlassian.net/browse/CRM457-621)

## Notes for reviewer
hopefully this make object building easier as there is now only a single way to do it... The next step is to add some documentation on how it all fits together

[CRM457-621]: https://dsdmoj.atlassian.net/browse/CRM457-621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ