### PR TITLE
use app-secrets secret for database url

### DIFF
--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -51,8 +51,8 @@ spec:
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:
-                  name: rds-postgresql-instance-output
-                  key: url
+                  name: app-secrets
+                  key: postgres_url
             - name: SECRET_KEY_BASE
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Description of change
Use app-secrets[postgres_url] instead of rds-postgresql-instance-output[url] for database url secret to prevent the secret clearing from re-deployments

## Link to relevant ticket

[Caseworker Build: Rspec Showing DB Access Error in Circle CI Pipeline](https://dsdmoj.atlassian.net/browse/CRM457-557)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature