### PR TITLE
Use Dev Auth in Development

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 feature_flags:
   dev_auth:
     local: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
-    development: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
+    development: <%= ENV.fetch("DEV_AUTH_ENABLED", true) %>
     uat: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
     production: false # must never be enabled in the live service
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 feature_flags:
   dev_auth:
     local: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
-    development: <%= ENV.fetch("DEV_AUTH_ENABLED", true) %>
+    development: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
     uat: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
     production: false # must never be enabled in the live service
 

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
             - name: RAILS_LOG_TO_STDOUT
               value: enabled
             - name: DEV_AUTH_ENABLED
-              value: 'true'
+              value: {{ .Values.secrets.devAuthEnabled | quote }}
             - name: ENV_NAME
               value: development
             - name: IS_LOCAL_DOCKER_ENV

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -62,6 +62,6 @@ autoscaling:
 
 secrets:
   environment: development
-
+  devAuthEnabled: true
 service_account:
   name: laa-assess-non-standard-magistrate-fee-dev-irsa

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -62,6 +62,7 @@ autoscaling:
 
 secrets:
   environment: uat
+  devAuthEnabled: false
 
 service_account:
   name: laa-assess-non-standard-magistrate-fee-prod-irsa

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -62,6 +62,7 @@ autoscaling:
 
 secrets:
   environment: uat
+  devAuthEnabled: false
 
 service_account:
   name: laa-assess-non-standard-magistrate-fee-uat-irsa


### PR DESCRIPTION
## Description of change
Turn on Dev Auth in development environment so that real Azure authentication isn't being used

## Link to relevant ticket

[Caseworker Build: Enable Dev Auth in Development](https://dsdmoj.atlassian.net/browse/CRM457-651)

