### PR TITLE
CRM457-657 - User assignment

### DIFF
--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -24,13 +24,11 @@ class ClaimsController < ApplicationController
     claim = Claim.find(params[:id])
 
     assignment = claim.assignments.first
+
     if assignment
       Claim.transaction do
-        Event::Unassignment.build(
-          claim: claim,
-          user: assignment.user,
-          current_user: current_user
-        )
+        Event::Unassignment.build(claim: claim, user: assignment.user, current_user: current_user)
+
         assignment.delete
       end
     end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -4,4 +4,36 @@ class ClaimsController < ApplicationController
     claims = claims.map { |claim| BaseViewModel.build(:all_claims, claim) }
     @pagy, @claims = pagy_array(claims)
   end
+
+  def new
+    claim = Claim.unassigned_claims(current_user).order(created_at: :desc).first
+
+    if claim
+      Claim.transaction do
+        claim.assignments.create!(user: current_user)
+        Event::Assignment.build(claim:, current_user:)
+      end
+
+      redirect_to claim_claim_details_path(claim)
+    else
+      redirect_to your_claims_path, flash: { notice: t('.no_pending_claims') }
+    end
+  end
+
+  def destroy
+    claim = Claim.find(params[:id])
+
+    Claim.transaction do
+      claim.current_assignments.each do |assignment|
+        Event::Unassignment.build(
+          claim: claim,
+          user: assignment.user,
+          current_user: current_user
+        )
+      end
+      claim.current_assignments.update_all(end_at: Time.now)
+    end
+
+    redirect_to your_claims_path
+  end
 end

--- a/app/controllers/claims_controller.rb
+++ b/app/controllers/claims_controller.rb
@@ -23,15 +23,16 @@ class ClaimsController < ApplicationController
   def destroy
     claim = Claim.find(params[:id])
 
-    Claim.transaction do
-      claim.current_assignments.each do |assignment|
+    assignment = claim.assignments.first
+    if assignment
+      Claim.transaction do
         Event::Unassignment.build(
           claim: claim,
           user: assignment.user,
           current_user: current_user
         )
+        assignment.delete
       end
-      claim.current_assignments.update_all(end_at: Time.now)
     end
 
     redirect_to your_claims_path

--- a/app/controllers/your_claims_controller.rb
+++ b/app/controllers/your_claims_controller.rb
@@ -1,9 +1,7 @@
 class YourClaimsController < ApplicationController
   def index
-    claims = Claim.your_claims
+    claims = Claim.your_claims(current_user)
     claims = claims.map { |claim| BaseViewModel.build(:your_claims, claim) }
     @pagy, @claims = pagy_array(claims)
-    # TODO: Next claim assignment needs to be done
-    @next_claim = Claim.unassigned_claims.order(created_at: :desc).first
   end
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -3,4 +3,6 @@ class Assignment < ApplicationRecord
   belongs_to :user
 
   validates :claim, uniqueness: true
+
+  delegate :display_name, to: :user
 end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -1,0 +1,6 @@
+class Assignment < ApplicationRecord
+  belongs_to :claim
+  belongs_to :user
+
+  validates :claim, uniqueness: { conditions: -> { where(end_at: nil) } }
+end

--- a/app/models/assignment.rb
+++ b/app/models/assignment.rb
@@ -2,5 +2,5 @@ class Assignment < ApplicationRecord
   belongs_to :claim
   belongs_to :user
 
-  validates :claim, uniqueness: { conditions: -> { where(end_at: nil) } }
+  validates :claim, uniqueness: true
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -1,6 +1,6 @@
 class Claim < ApplicationRecord
   has_many :events, dependent: :destroy
-  has_many :assignments
+  has_many :assignments, dependent: :destroy
 
   validates :risk, inclusion: { in: %w[low medium high] }
   validates :current_version, numericality: { only_integer: true, greater_than: 0 }

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -1,5 +1,8 @@
 class Claim < ApplicationRecord
   has_many :events, dependent: :destroy
+  has_many :assignments
+  has_many :current_assignments, -> { where(created_at: (..Time.now), end_at: nil) }, class_name: 'Assignment'
+  has_many :unassignments, -> { where.not(end_at: nil) }, class_name: 'Assignment'
 
   validates :risk, inclusion: { in: %w[low medium high] }
   validates :current_version, numericality: { only_integer: true, greater_than: 0 }
@@ -7,6 +10,14 @@ class Claim < ApplicationRecord
   scope :pending_decision, -> { where.not(state: MakeDecisionForm::STATES) }
   scope :decision_made, -> { where.not(state: 'submitted') }
   # TODO: - will add the filtering to current user once we have user assignment setup
-  scope :your_claims, -> { where(state: 'submitted') }
-  scope :unassigned_claims, -> { where(current_version: 1) }
+  scope :your_claims, -> (user) do
+    joins(:current_assignments)
+    .where(state: 'submitted', assignments: { user_id: user.id })
+    .distinct
+  end
+  scope :unassigned_claims, -> (user) do
+    left_joins(:current_assignments)
+    .where(state: 'submitted', assignments: { id: nil })
+    .where.not(id: Claim.joins(:unassignments).where(assignments: { user_id: user.id }))
+  end
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -7,13 +7,13 @@ class Claim < ApplicationRecord
 
   scope :pending_decision, -> { where.not(state: MakeDecisionForm::STATES) }
   scope :decision_made, -> { where.not(state: 'submitted') }
-  scope :your_claims, -> (user) do
+  scope :your_claims, lambda { |user|
     joins(:assignments)
-    .where(state: 'submitted', assignments: { user_id: user.id })
-  end
-  scope :unassigned_claims, -> (user) do
-    left_joins(:assignments)
-    .where(state: 'submitted', assignments: { id: nil })
-    .where.not(id: Event::Unassignment.where(primary_user_id: user.id).select(:claim_id))
-  end
+      .where(state: 'submitted', assignments: { user_id: user.id })
+  }
+  scope :unassigned_claims, lambda { |user|
+    where.missing(:assignments)
+         .where(state: 'submitted')
+         .where.not(id: Event::Unassignment.where(primary_user_id: user.id).select(:claim_id))
+  }
 end

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -1,23 +1,19 @@
 class Claim < ApplicationRecord
   has_many :events, dependent: :destroy
   has_many :assignments
-  has_many :current_assignments, -> { where(created_at: (..Time.now), end_at: nil) }, class_name: 'Assignment'
-  has_many :unassignments, -> { where.not(end_at: nil) }, class_name: 'Assignment'
 
   validates :risk, inclusion: { in: %w[low medium high] }
   validates :current_version, numericality: { only_integer: true, greater_than: 0 }
 
   scope :pending_decision, -> { where.not(state: MakeDecisionForm::STATES) }
   scope :decision_made, -> { where.not(state: 'submitted') }
-  # TODO: - will add the filtering to current user once we have user assignment setup
   scope :your_claims, -> (user) do
-    joins(:current_assignments)
+    joins(:assignments)
     .where(state: 'submitted', assignments: { user_id: user.id })
-    .distinct
   end
   scope :unassigned_claims, -> (user) do
-    left_joins(:current_assignments)
+    left_joins(:assignments)
     .where(state: 'submitted', assignments: { id: nil })
-    .where.not(id: Claim.joins(:unassignments).where(assignments: { user_id: user.id }))
+    .where.not(id: Event::Unassignment.where(primary_user_id: user.id).select(:claim_id))
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -5,7 +5,12 @@ class Event < ApplicationRecord
   self.inheritance_column = :event_type
 
   PUBLIC_EVENTS = ['Event::Decision'].freeze
-  HISTORY_EVENTS = ['Event::NewVersion', 'Event::Decision', 'Event::ChangeRisk', 'Event::Note'].freeze
+  HISTORY_EVENTS = [
+    'Event::Decision',
+    'Event::ChangeRisk',
+    'Event::NewVersion',
+    'Event::Note'
+  ].freeze
   scope :history, -> { where(event_type: HISTORY_EVENTS).order(created_at: :desc) }
 
   # simplifies the rehydrate process

--- a/app/models/event/assignment.rb
+++ b/app/models/event/assignment.rb
@@ -1,0 +1,11 @@
+class Event
+  class Assignment < Event
+    def self.build(claim:, current_user:)
+      create(
+        claim: claim,
+        primary_user: current_user,
+        claim_version: claim.current_version
+      )
+    end
+  end
+end

--- a/app/models/event/unassignment.rb
+++ b/app/models/event/unassignment.rb
@@ -1,0 +1,14 @@
+class Event
+  class Unassignment < Event
+    belongs_to :secondary_user, optional: true, class_name: 'User'
+
+    def self.build(claim:, user:, current_user:)
+      create(
+        claim: claim,
+        primary_user: user,
+        secondary_user: user == current_user ? nil : current_user,
+        claim_version: claim.current_version,
+      )
+    end
+  end
+end

--- a/app/view_models/v1/all_claims.rb
+++ b/app/view_models/v1/all_claims.rb
@@ -4,7 +4,7 @@ module V1
     attribute :defendants
     attribute :firm_office
     attribute :created_at, :date
-    attribute :id
+    attribute :claim
 
     def main_defendant_name
       main_defendant = defendants.detect { |defendant| defendant['main'] }
@@ -20,12 +20,12 @@ module V1
     end
 
     def case_worker_name
-      '#Pending#'
+      claim.assignments.first&.display_name || I18n.t('claims.index.unassigned')
     end
 
     def table_fields
       [
-        { laa_reference: laa_reference, claim_id: id },
+        { laa_reference: laa_reference, claim_id: claim.id },
         firm_name,
         main_defendant_name,
         date_created,

--- a/app/views/claims/_claim_summary.html.erb
+++ b/app/views/claims/_claim_summary.html.erb
@@ -26,6 +26,6 @@
       </p>
     </div>
     <div class="govuk-grid-column-one-thirds govuk-!-padding-top-2">
-      <%= button_to(t(".remove_from_list"), '#', class: "govuk-button govuk-button--secondary", data_module: "govuk-button") %>
+      <%= button_to(t(".remove_from_list"), claim_path(claim), method: :delete, class: "govuk-button govuk-button--secondary", data_module: "govuk-button") %>
     </div>
   </div>

--- a/app/views/your_claims/index.html.erb
+++ b/app/views/your_claims/index.html.erb
@@ -3,11 +3,16 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
+    <% if @claims.none? %>
+      <h2 class="govuk-body-l"><%= t('.no_claims') %></h2>
+    <% end %>
     <div class="govuk-button-group">
-      <%= govuk_button_link_to(t('.next_claim'),claim_claim_details_path(@next_claim)) %>
+      <%= govuk_button_link_to(t('.next_claim'), new_claim_path) %>
       <%= govuk_link_to(t('.all_claims'), claims_path, { no_visited_state: true }) %>
     </div>
-    <%= render 'your_claims_table', { claims: @claims } %>
-    <%= render "shared/pagination", { pagy: @pagy, item: t('.table_info_item')} %>
+    <% if @claims.any? %>
+      <%= render 'your_claims_table', { claims: @claims } %>
+      <%= render "shared/pagination", { pagy: @pagy, item: t('.table_info_item')} %>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en/claims.yml
+++ b/config/locales/en/claims.yml
@@ -1,6 +1,8 @@
 ---
 en:
   claims:
+    new:
+      no_pending_claims: There are no claims waiting to be allocated.
     index:
       page_title: Assess a non-standard magistrates’ court payment
       heading: "All claims"

--- a/config/locales/en/claims.yml
+++ b/config/locales/en/claims.yml
@@ -7,6 +7,7 @@ en:
       page_title: Assess a non-standard magistrates’ court payment
       heading: "All claims"
       table_info_item: "claim"
+      unassigned: Unassigned
     claims_table:
       table_heading: "All Claims"
       laa_reference: "LAA reference"

--- a/config/locales/en/your_claims.yml
+++ b/config/locales/en/your_claims.yml
@@ -7,6 +7,7 @@ en:
       table_info_item: "claim"
       next_claim: "Assess next claim"
       all_claims: "Check all claims"
+      no_claims: There are no claims allocated for you to assess.
     your_claims_table:
       table_heading: "Your claims"
       laa_reference: "LAA reference"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -39,7 +39,7 @@ Rails.application.routes.draw do
 
   resources :application_versions, only: [:update]
   resources :landing, only: [:index]
-  resources :claims, only: [:index] do
+  resources :claims, only: [:new, :index, :destroy] do
     resource :claim_details, only: [:show]
     resource :adjustments, only: [:show]
     resources :work_items, only: [:index]

--- a/db/migrate/20231102112118_create_assignments.rb
+++ b/db/migrate/20231102112118_create_assignments.rb
@@ -1,0 +1,11 @@
+class CreateAssignments < ActiveRecord::Migration[7.1]
+  def change
+    create_table :assignments, id: :uuid do |t|
+      t.references :claim, null: false, foreign_key: true, type: :uuid
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.datetime :end_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20231102112118_create_assignments.rb
+++ b/db/migrate/20231102112118_create_assignments.rb
@@ -3,7 +3,6 @@ class CreateAssignments < ActiveRecord::Migration[7.1]
     create_table :assignments, id: :uuid do |t|
       t.references :claim, null: false, foreign_key: true, type: :uuid
       t.references :user, null: false, foreign_key: true, type: :uuid
-      t.datetime :end_at
 
       t.timestamps
     end

--- a/db/migrate/20231102112118_create_assignments.rb
+++ b/db/migrate/20231102112118_create_assignments.rb
@@ -1,7 +1,7 @@
 class CreateAssignments < ActiveRecord::Migration[7.1]
   def change
     create_table :assignments, id: :uuid do |t|
-      t.references :claim, null: false, foreign_key: true, type: :uuid
+      t.references :claim, null: false, foreign_key: true, index: { unique: true }, type: :uuid
       t.references :user, null: false, foreign_key: true, type: :uuid
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_25_145658) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_02_112118) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
+
+  create_table "assignments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "claim_id", null: false
+    t.uuid "user_id", null: false
+    t.datetime "end_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["claim_id"], name: "index_assignments_on_claim_id"
+    t.index ["user_id"], name: "index_assignments_on_user_id"
+  end
 
   create_table "claims", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "state"
@@ -60,6 +70,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_25_145658) do
     t.index ["email"], name: "index_users_on_email"
   end
 
+  add_foreign_key "assignments", "claims"
+  add_foreign_key "assignments", "users"
   add_foreign_key "events", "claims"
   add_foreign_key "events", "users", column: "primary_user_id"
   add_foreign_key "events", "users", column: "secondary_user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_02_112118) do
   create_table "assignments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "claim_id", null: false
     t.uuid "user_id", null: false
-    t.datetime "end_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["claim_id"], name: "index_assignments_on_claim_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_02_112118) do
     t.uuid "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["claim_id"], name: "index_assignments_on_claim_id"
+    t.index ["claim_id"], name: "index_assignments_on_claim_id", unique: true
     t.index ["user_id"], name: "index_assignments_on_user_id"
   end
 

--- a/db/seeds/f1ba0909-020f-4373-a167-9100923bdcaa/version.json
+++ b/db/seeds/f1ba0909-020f-4373-a167-9100923bdcaa/version.json
@@ -7,7 +7,10 @@
     "data": {
         "id": "f1ba0909-020f-4373-a167-9100923bdcaa",
         "ufn": "111111/111",
-        "plea": "bind_over",
+        "plea": {
+            "value": "bind_over",
+            "en": "Bind Over"
+        },
         "court": "Aldershot Magistrates' Court",
         "gender": null,
         "status": "completed",
@@ -25,17 +28,20 @@
             "reference_number": "jj",
             "contact_full_name": null
         },
-        "claim_type": "non_standard_magistrate",
+        "claim_type": {
+            "value": "non_standard_magistrate",
+            "en": "Non-standard fee - magistrate"
+        },
         "cntp_order": null,
         "conclusion": "",
         "created_at": "2023-08-09T16:44:55.969Z",
         "defendants": [
             {
                 "id": "92b44456-59ae-4305-9650-607c2d306d51",
-                "maat": "sss",
+                "maat": "ZZ1234",
                 "main": true,
                 "position": 1,
-                "full_name": "ss ss"
+                "full_name": "Jim Bob"
             }
         ],
         "disability": null,
@@ -53,7 +59,7 @@
                     "en": "Attendance without counsel",
                     "value": "attendance_without_counsel"
                 },
-                "fee_earner": "aaa",
+                "fee_earner": "James Dean",
                 "time_spent": 72,
                 "completed_on": "2022-01-01"
             },
@@ -65,7 +71,7 @@
                     "en": "Travel",
                     "value": "travel"
                 },
-                "fee_earner": "www",
+                "fee_earner": "James Dean",
                 "time_spent": 284,
                 "completed_on": "2022-01-01"
             },
@@ -77,7 +83,7 @@
                     "en": "Preparation",
                     "value": "preparation"
                 },
-                "fee_earner": "sss",
+                "fee_earner": "Jake Sparrow",
                 "time_spent": 142,
                 "completed_on": "2022-02-02"
             },
@@ -89,21 +95,24 @@
                     "en": "Preparation",
                     "value": "preparation"
                 },
-                "fee_earner": "ddd",
+                "fee_earner": "James Dean",
                 "time_spent": 671,
                 "completed_on": "2023-01-01"
             }
         ],
         "firm_office": {
-            "name": "dd",
-            "town": "hh",
+            "name": "Downtown Law",
+            "town": "Downtown",
             "postcode": "aa1 2bb",
             "previous_id": null,
             "account_number": "hh",
             "address_line_1": "hh",
             "address_line_2": "hh"
         },
-        "matter_type": "3",
+        "matter_type": {
+            "value": "3",
+            "en": "Sexual offences and associated offences against children"
+        },
         "office_code": "1A123B",
         "work_before": "no",
         "youth_count": "no",
@@ -114,7 +123,7 @@
             {
                 "id": "abf97dd9-ef21-4e75-b8f8-6b65cb5cbbb0",
                 "miles": "111.0",
-                "details": "sss",
+                "details": "Driving my car",
                 "pricing": 0.45,
                 "vat_rate": 0.2,
                 "apply_vat": null,
@@ -134,7 +143,7 @@
             {
                 "id": "18032dc2-357c-4a70-a009-0b85e32b6ef8",
                 "miles": null,
-                "details": "222",
+                "details": "Millions of peaches",
                 "pricing": 1.0,
                 "vat_rate": 0.2,
                 "apply_vat": null,
@@ -154,7 +163,7 @@
             {
                 "id": "5c796ff8-a14b-4359-b02c-9ffe5fc669cb",
                 "miles": null,
-                "details": "sss",
+                "details": "What report",
                 "pricing": 1.0,
                 "vat_rate": 0.2,
                 "apply_vat": null,
@@ -176,7 +185,10 @@
         "laa_reference": "LAA-FHaMVK",
         "rep_order_date": "2012-12-12",
         "signatory_name": "dave aa",
-        "hearing_outcome": "CP03",
+        "hearing_outcome": {
+            "value": "CP03",
+            "en": "Representation order withdrawn"
+        },
         "work_after_date": null,
         "agent_instructed": "no",
         "assigned_counsel": "no",

--- a/spec/controllers/claims_controller_spec.rb
+++ b/spec/controllers/claims_controller_spec.rb
@@ -9,9 +9,8 @@ RSpec.describe ClaimsController do
 
   describe '#new' do
     context 'when a claim is available to assign' do
-
       it 'creates an assignment and event' do
-        claim = create(:claim)
+        create(:claim)
 
         expect do
           expect { get :new }.to change(Assignment, :count).by(1)
@@ -32,7 +31,7 @@ RSpec.describe ClaimsController do
         get :new
 
         expect(response).to redirect_to(your_claims_path)
-        expect(flash[:notice]).to eq("There are no claims waiting to be allocated.")
+        expect(flash[:notice]).to eq('There are no claims waiting to be allocated.')
       end
     end
   end

--- a/spec/controllers/claims_controller_spec.rb
+++ b/spec/controllers/claims_controller_spec.rb
@@ -1,9 +1,77 @@
 require 'rails_helper'
 
 RSpec.describe ClaimsController do
-  context 'index' do
+  describe '#index' do
     it 'does not raise any errors' do
       expect { get :index }.not_to raise_error
+    end
+  end
+
+  describe '#new' do
+    context 'when a claim is available to assign' do
+
+      it 'creates an assignment and event' do
+        claim = create(:claim)
+
+        expect do
+          expect { get :new }.to change(Assignment, :count).by(1)
+        end.to change(Event::Assignment, :count).by(1)
+      end
+
+      it 'redirects to the assigned claim' do
+        claim = create(:claim)
+
+        get :new
+
+        expect(response).to redirect_to(claim_claim_details_path(claim))
+      end
+    end
+
+    context 'when a claim is not available to assign' do
+      it 'redirects to Your Claims with a flash notice' do
+        get :new
+
+        expect(response).to redirect_to(your_claims_path)
+        expect(flash[:notice]).to eq("There are no claims waiting to be allocated.")
+      end
+    end
+  end
+
+  describe '#destroy' do
+    let(:claim) { create(:claim) }
+
+    context 'when an assignment exists' do
+      let(:user) { create(:caseworker) }
+
+      it 'deletes the assignment and create an Unassignment event' do
+        claim.assignments.create(user:)
+
+        expect do
+          expect { delete :destroy, params: { id: claim.id } }.to change(Assignment, :count).by(-1)
+        end.to change(Event::Unassignment, :count).by(1)
+      end
+
+      it 'redirects to Your Claims' do
+        claim.assignments.create(user:)
+
+        delete :destroy, params: { id: claim.id }
+
+        expect(response).to redirect_to(your_claims_path)
+      end
+    end
+
+    context 'when no assignment exists' do
+      it 'does nothing' do
+        expect(Event::Unassignment).not_to receive(:build)
+
+        delete :destroy, params: { id: claim.id }
+      end
+
+      it 'redirects to Your Claims' do
+        delete :destroy, params: { id: claim.id }
+
+        expect(response).to redirect_to(your_claims_path)
+      end
     end
   end
 end

--- a/spec/models/claims_spec.rb
+++ b/spec/models/claims_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe Claim do
+  let(:claim) { create(:claim) }
+
+  describe '#unassigned_claims' do
+    let(:user) { create(:caseworker) }
+
+    it 'returns claims oldest to youngest' do
+      claim1 = create(:claim)
+      claim2 = create(:claim)
+      claim3 = create(:claim)
+
+      expect(described_class.unassigned_claims(user)).to eq([claim1, claim2, claim3])
+    end
+
+    it 'does not include claims which have already been assigned' do
+      claim.assignments.create(user: create(:caseworker))
+
+      expect(described_class.unassigned_claims(user)).to eq([])
+    end
+
+    it 'includes claims that have an ended assignment' do
+      claim.assignments.create(user: create(:caseworker), end_at:Time.now)
+
+      expect(described_class.unassigned_claims(user)).to eq([claim])
+    end
+
+    it 'does not include claims that have an ended assignment for the user' do
+      claim.assignments.create(user: user, end_at:Time.now)
+
+      expect(described_class.unassigned_claims(user)).to eq([])
+    end
+  end
+
+  describe 'claim assignment' do
+    let(:user) { create(:caseworker) }
+
+    it 'does not allow a claim to have multiple live assignments' do
+      claim.assignments.create!(user: user)
+      assignment = claim.assignments.new(user: user)
+
+      expect(assignment).not_to be_valid
+      expect(assignment.errors.of_kind?(:claim, :taken)).to be(true)
+    end
+  end
+end

--- a/spec/models/claims_spec.rb
+++ b/spec/models/claims_spec.rb
@@ -20,14 +20,8 @@ RSpec.describe Claim do
       expect(described_class.unassigned_claims(user)).to eq([])
     end
 
-    it 'includes claims that have an ended assignment' do
-      claim.assignments.create(user: create(:caseworker), end_at:Time.now)
-
-      expect(described_class.unassigned_claims(user)).to eq([claim])
-    end
-
-    it 'does not include claims that have an ended assignment for the user' do
-      claim.assignments.create(user: user, end_at:Time.now)
+    it 'does not include claims the user has been unassigned from' do
+      Event::Unassignment.build(claim:, user:, current_user: user)
 
       expect(described_class.unassigned_claims(user)).to eq([])
     end

--- a/spec/models/claims_spec.rb
+++ b/spec/models/claims_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Claim do
     end
 
     it 'does not include claims the user has been unassigned from' do
-      Event::Unassignment.build(claim:, user:, current_user: user)
+      Event::Unassignment.build(claim: claim, user: user, current_user: user)
 
       expect(described_class.unassigned_claims(user)).to eq([])
     end
@@ -31,8 +31,8 @@ RSpec.describe Claim do
     let(:user) { create(:caseworker) }
 
     it 'does not allow a claim to have multiple live assignments' do
-      claim.assignments.create!(user: user)
-      assignment = claim.assignments.new(user: user)
+      claim.assignments.create!(user:)
+      assignment = claim.assignments.new(user:)
 
       expect(assignment).not_to be_valid
       expect(assignment.errors.of_kind?(:claim, :taken)).to be(true)

--- a/spec/models/event/assignment_spec.rb
+++ b/spec/models/event/assignment_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe Event::Assignment do
+  subject { described_class.build(claim:, current_user:) }
+
+  let(:claim) { create(:claim) }
+  let(:current_user) { create(:caseworker) }
+
+  it 'can build a new record' do
+    expect(subject).to have_attributes(
+      claim_id: claim.id,
+      primary_user_id: current_user.id,
+      claim_version: 1,
+      event_type: 'Event::Assignment',
+    )
+  end
+end

--- a/spec/models/event/unassignment_spec.rb
+++ b/spec/models/event/unassignment_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe Event::Unassignment do
+  subject { described_class.build(claim:, user:, current_user:) }
+
+  let(:claim) { create(:claim) }
+  let(:user) { create(:caseworker) }
+
+  context 'when user is the same as current user' do
+    let(:current_user) { user }
+
+    it 'can build a new record without a secondary user' do
+      expect(subject).to have_attributes(
+        claim_id: claim.id,
+        primary_user_id: user.id,
+        claim_version: 1,
+        event_type: 'Event::Unassignment',
+      )
+    end
+  end
+
+  context 'when user is the same as current user' do
+    let(:current_user) { create(:supervisor) }
+
+    it 'can build a new record without a secondary user' do
+      expect(subject).to have_attributes(
+        claim_id: claim.id,
+        primary_user_id: user.id,
+        secondary_user_id: current_user.id,
+        claim_version: 1,
+        event_type: 'Event::Unassignment',
+      )
+    end
+  end
+end

--- a/spec/models/event/unassignment_spec.rb
+++ b/spec/models/event/unassignment_spec.rb
@@ -19,10 +19,10 @@ RSpec.describe Event::Unassignment do
     end
   end
 
-  context 'when user is the same as current user' do
+  context 'when user is different to the current user' do
     let(:current_user) { create(:supervisor) }
 
-    it 'can build a new record without a secondary user' do
+    it 'can build a new record with a secondary user' do
       expect(subject).to have_attributes(
         claim_id: claim.id,
         primary_user_id: user.id,

--- a/spec/view_models/v1/all_claims_spec.rb
+++ b/spec/view_models/v1/all_claims_spec.rb
@@ -2,14 +2,14 @@ require 'rails_helper'
 
 RSpec.describe V1::AllClaims, type: :view_model do
   subject(:all_claims) do
-    described_class.new(laa_reference:, defendants:, firm_office:, created_at:, id:)
+    described_class.new(laa_reference:, defendants:, firm_office:, created_at:, claim:)
   end
 
   let(:laa_reference) { '1234567890' }
   let(:defendants) { [{ 'full_name' => 'John Doe', 'main' => true }, 'main' => false, 'full_name' => 'jimbob'] }
   let(:firm_office) { { 'name' => 'Acme Law Firm' } }
   let(:created_at) { Time.zone.today }
-  let(:id) { 1 }
+  let(:claim) { build(:claim, id: SecureRandom.uuid) }
 
   describe '#main_defendant_name' do
     it 'returns the name of the main defendant' do
@@ -35,19 +35,30 @@ RSpec.describe V1::AllClaims, type: :view_model do
   end
 
   describe '#case_worker_name' do
-    it 'returns the pending status' do
-      expect(all_claims.case_worker_name).to eq('#Pending#')
+    context 'when not assigned' do
+      it 'returns the unassigned status' do
+        expect(all_claims.case_worker_name).to eq('Unassigned')
+      end
+    end
+
+    context 'when assigned' do
+      it 'returns the caseworkers name' do
+        assignment = instance_double(Assignment, display_name: 'John Wick')
+        allow(claim).to receive(:assignments).and_return([assignment])
+
+        expect(all_claims.case_worker_name).to eq('John Wick')
+      end
     end
   end
 
   describe '#table_fields' do
     it 'returns an array of table fields' do
       expected_fields = [
-        { laa_reference: '1234567890', claim_id: 1 },
+        { laa_reference: '1234567890', claim_id: claim.id },
         'Acme Law Firm',
         'John Doe',
         { text: I18n.l(Time.zone.today, format: '%-d %b %Y'), sort_value: Time.zone.today.to_fs(:db) },
-        '#Pending#'
+        'Unassigned'
       ]
       expect(all_claims.table_fields).to eq(expected_fields)
     end

--- a/spec/view_models/v1/contact_details_spec.rb
+++ b/spec/view_models/v1/contact_details_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe V1::ContactDetails do
     end
   end
 
-  # rubocop:disable Rspec/ExampleLength
+  # rubocop:disable RSpec/ExampleLength
   describe '#rows' do
     it 'has correct structure' do
       subject = described_class.new(
@@ -31,7 +31,7 @@ RSpec.describe V1::ContactDetails do
       expect(subject.rows).to have_key(:data)
     end
   end
-  # rubocop:enable Rspec/ExampleLength
+  # rubocop:enable RSpec/ExampleLength
 
   describe '#data' do
     context 'One line in firm address' do

--- a/spec/view_models/v1/defendant_details_spec.rb
+++ b/spec/view_models/v1/defendant_details_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe V1::DefendantDetails do
     end
   end
 
-  # rubocop:disable Rspec/ExampleLength
+  # rubocop:disable RSpec/ExampleLength
   describe '#rows' do
     it 'has correct structure' do
       subject = described_class.new(
@@ -42,7 +42,7 @@ RSpec.describe V1::DefendantDetails do
       expect(subject.rows).to have_key(:data)
     end
   end
-  # rubocop:enable Rspec/ExampleLength
+  # rubocop:enable RSpec/ExampleLength
 
   describe '#data' do
     context 'Main defendant and additional defendants' do

--- a/spec/view_models/v1/hearing_details_spec.rb
+++ b/spec/view_models/v1/hearing_details_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe V1::HearingDetails do
     end
   end
 
-  # rubocop:disable Rspec/ExampleLength
+  # rubocop:disable RSpec/ExampleLength
   describe '#rows' do
     it 'has correct structure' do
       subject = described_class.new(
@@ -32,7 +32,7 @@ RSpec.describe V1::HearingDetails do
       expect(subject.rows).to have_key(:data)
     end
   end
-  # rubocop:enable Rspec/ExampleLength
+  # rubocop:enable RSpec/ExampleLength
 
   describe '#data' do
     subject = described_class.new(


### PR DESCRIPTION
## Description of change
user assignment to claims

## Link to relevant ticket

[CRM457-657](https://dsdmoj.atlassian.net/browse/CRM457-657)

## Notes to reviewer

User can now be assigned and unassigned from a claim, this:
* creates/deletes and Assignment record
* creates events that can be queries to determine if a user has been unassigned from a claim and hence can't be automatically reassigned

I was thinking a user should be unassigned when the claim is assess (i.e. marked as granted) as at this stage all the data is deleted meaning the Assignment record is just lost - something to think more about when we get to appeals/more info/etc...

[CRM457-657]: https://dsdmoj.atlassian.net/browse/CRM457-657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ