### PR TITLE
[CRM457-547] Iterate disbursement adjustment tab

### DIFF
--- a/app/view_models/v1/disbursement.rb
+++ b/app/view_models/v1/disbursement.rb
@@ -63,6 +63,7 @@ module V1
       [
         type_name,
         NumberTo.pounds(provider_requested_total_cost),
+        apply_vat == 'true' ? format_vat_rate(vat_rate) : '0%',
         adjustments.any? ? NumberTo.pounds(caseworker_total_cost) : '',
       ]
     end

--- a/app/views/disbursements/_disbursements_total.html.erb
+++ b/app/views/disbursements/_disbursements_total.html.erb
@@ -1,0 +1,9 @@
+<%= govuk_details(summary_text: t('.link_title')) do %>
+  <%=
+    with_vat_total= NumberTo.pounds(disbursements.flat_map(&:last).sum(&:caseworker_total_cost))
+    without_vat_total= NumberTo.pounds(disbursements.flat_map(&:last).sum(&:total_cost_without_vat))
+    head = [t('.without_vat'), t('.with_vat')]
+    rows = [[without_vat_total, with_vat_total ]]
+    govuk_table( head:, rows:)
+  %>
+<% end %>

--- a/app/views/disbursements/index.html.erb
+++ b/app/views/disbursements/index.html.erb
@@ -8,11 +8,12 @@
     <div class="govuk-heading-l">
       <%= NumberTo.pounds(disbursements.flat_map(&:last).sum(&:caseworker_total_cost)) %>
     </div>
+    <%= render "disbursements_total",  { disbursements: disbursements } %>
   </div>
 
   <% disbursements.each do |disbursement_date, disbursements_for_date| %>
     <%=
-      head = [t('.disbursement'), t('.requested'), t('.adjusted'), t('.action')]
+      head = [t('.disbursement'), t('.requested'),t('.vat_applied'), t('.adjusted'), t('.action')]
       rows = disbursements_for_date.map do |disbursement|
         [*disbursement.table_fields, { text: link_to(t('.change'), edit_claim_disbursement_path(claim_id: claim.id, id: disbursement.id), data: { turbo: 'false' }) }]
       end

--- a/config/locales/en/claims.yml
+++ b/config/locales/en/claims.yml
@@ -58,7 +58,8 @@ en:
       disbursement_total: Disbursement total
       disbursement: Disbursement
       requested: Provider requested
-      adjusted: Adjusted
+      vat_applied: VAT applied
+      adjusted: Caseworker allowed
       action: Action
       change: Change
   adjustments:

--- a/config/locales/en/disbursements.yml
+++ b/config/locales/en/disbursements.yml
@@ -1,6 +1,10 @@
 ---
 en:
   disbursements:
+    disbursements_total:
+      link_title: View disbursement total
+      without_vat: Without VAT
+      with_vat: With VAT
     edit:
       page_title: Adjust a disbursement
       heading: Adjust a disbursement

--- a/spec/system/disbursements_spec.rb
+++ b/spec/system/disbursements_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Disbursements' do
       expect(page).to have_content(
         'Apples' \
         '£100.00' \
+        '0%' \
         'Change'
       )
     end
@@ -27,6 +28,7 @@ RSpec.describe 'Disbursements' do
       expect(page).to have_content(
         'Apples' \
         '£100.00' \
+        '0%' \
         '£0.00' \
         'Change'
       )
@@ -40,6 +42,7 @@ RSpec.describe 'Disbursements' do
       expect(page).to have_content(
         'Apples' \
         '£100.00' \
+        '0%' \
         'Change'
       )
     end

--- a/spec/view_models/v1/disbursement_spec.rb
+++ b/spec/view_models/v1/disbursement_spec.rb
@@ -82,14 +82,21 @@ RSpec.describe V1::Disbursement do
     it 'returns the fields for the table display if no adjustments' do
       allow(disbursement).to receive_messages(disbursement_type: 'Car')
       disbursement.adjustments = []
-      expect(disbursement.table_fields).to eq(['Car', '£10.00', ''])
+      expect(disbursement.table_fields).to eq(['Car', '£10.00', '0%', ''])
     end
 
     it 'returns an array with the correct fields if there are adjustments' do
       allow(disbursement).to receive_messages(type_name: 'type', provider_requested_total_cost: 100,
                                               caseworker_total_cost: 200)
       disbursement.adjustments = [1]
-      expected_fields = ['type', '£100.00', '£200.00']
+      expected_fields = ['type', '£100.00', '0%', '£200.00']
+      expect(disbursement.table_fields).to eq(expected_fields)
+    end
+
+    it 'returns the formatted vat rate when apply_vat is true' do
+      allow(disbursement).to receive_messages(type_name: 'type', provider_requested_total_cost: 100,
+                                              caseworker_total_cost: 200, apply_vat: 'true', format_vat_rate: '20%')
+      expected_fields = ['type', '£100.00', '20%', '']
       expect(disbursement.table_fields).to eq(expected_fields)
     end
   end


### PR DESCRIPTION
## Description of change

- Added a total table under Disbursement total
- Added a new column - Vat applied
- Renamed column 'Adjusted' to 'Caseworker allowed'

## Link to relevant ticket

[CRM457-547](https://dsdmoj.atlassian.net/browse/CRM457-547)



## Screenshots of changes 

### Before changes:
![Screenshot 2023-11-14 at 09 37 48](https://github.com/ministryofjustice/laa-assess-non-standard-magistrate-fee/assets/90189839/06af4113-0f85-486f-961e-04fafa41ca8b)

### After changes:
![Screenshot 2023-11-14 at 09 11 15](https://github.com/ministryofjustice/laa-assess-non-standard-magistrate-fee/assets/90189839/05d344b1-c2fa-40f1-bffa-a0cac523f258)


[CRM457-547]: https://dsdmoj.atlassian.net/browse/CRM457-547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ