### PR TITLE
Fix: Caseworker App Failing to Update from App Store When Schema Version Not 1

### DIFF
--- a/app/forms/make_decision_form.rb
+++ b/app/forms/make_decision_form.rb
@@ -4,9 +4,9 @@ class MakeDecisionForm
   include ActiveRecord::AttributeAssignment
 
   STATES = [
-    GRANT = 'grant'.freeze,
+    GRANTED = 'granted'.freeze,
     PART_GRANT = 'part_grant'.freeze,
-    REJECT = 'reject'.freeze
+    REJECTED = 'rejected'.freeze
   ].freeze
 
   attribute :id
@@ -18,7 +18,7 @@ class MakeDecisionForm
   validates :claim, presence: true
   validates :state, inclusion: { in: STATES }
   validates :partial_comment, presence: true, if: -> { state == PART_GRANT }
-  validates :reject_comment, presence: true, if: -> { state == REJECT }
+  validates :reject_comment, presence: true, if: -> { state == REJECTED }
 
   def save
     return false unless valid?
@@ -39,7 +39,7 @@ class MakeDecisionForm
     case state
     when PART_GRANT
       partial_comment
-    when REJECT
+    when REJECTED
       reject_comment
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,9 +60,9 @@ module ApplicationHelper
 
   def accessed_colour(state)
     {
-      'grant' => 'green',
+      'granted' => 'green',
       'part-grant' => 'blue',
-      'reject' => 'red'
+      'rejected' => 'red'
     }[state]
   end
 end

--- a/app/models/event/decision.rb
+++ b/app/models/event/decision.rb
@@ -18,6 +18,10 @@ class Event
       details['comment']
     end
 
+    def title
+      t("title.#{details['to']}", **title_options)
+    end
+
     private
 
     def title_options

--- a/app/services/receive_application_metadata.rb
+++ b/app/services/receive_application_metadata.rb
@@ -14,7 +14,7 @@ class ReceiveApplicationMetadata
 
     # as the provider can't resubmit let just do this as simple as possible
     # and avoid unnessessary pulls
-    return unless claim.save
+    return unless claim.save && claim.state == 'submitted'
 
     PullLatestVersionData.perform_later(claim)
   end

--- a/app/services/receive_application_metadata.rb
+++ b/app/services/receive_application_metadata.rb
@@ -14,7 +14,7 @@ class ReceiveApplicationMetadata
 
     # as the provider can't resubmit let just do this as simple as possible
     # and avoid unnessessary pulls
-    return unless claim.save && claim.current_version == 1
+    return unless claim.save
 
     PullLatestVersionData.perform_later(claim)
   end

--- a/app/view_models/v1/assessed_claims.rb
+++ b/app/view_models/v1/assessed_claims.rb
@@ -27,11 +27,11 @@ module V1
 
     def status(item)
       case item
-      when 'grant'
+      when 'granted'
         { colour: 'green', text: item, sort_value: 1 }
       when 'part_grant'
         { colour: 'blue', text: item, sort_value: 2 }
-      when 'reject'
+      when 'rejected'
         { colour: 'red', text: item, sort_value: 3 }
       else
         { colour: 'grey', text: item, sort_value: 4 }

--- a/app/views/make_decisions/edit.html.erb
+++ b/app/views/make_decisions/edit.html.erb
@@ -10,11 +10,11 @@
     <%= form_with model: decision, url: claim_make_decision_path(claim_id: decision.id), method: :put, id: dom_id(decision) do |f| %>
       <%= govuk_error_summary(decision) %>
       <%= f.govuk_radio_buttons_fieldset :state, legend: { size: 's' } do %>
-        <%= f.govuk_radio_button :state, MakeDecisionForm::GRANT %>
+        <%= f.govuk_radio_button :state, MakeDecisionForm::GRANTED %>
         <%= f.govuk_radio_button :state, MakeDecisionForm::PART_GRANT do %>
           <%= f.govuk_text_area :partial_comment, width: 'one-third', autocomplete: 'off', label: { size: 'm' } %>
         <% end %>
-        <%= f.govuk_radio_button :state, MakeDecisionForm::REJECT do %>
+        <%= f.govuk_radio_button :state, MakeDecisionForm::REJECTED do %>
           <%= f.govuk_text_area :reject_comment, width: 'one-third', autocomplete: 'off', label: { size: 'm' } %>
         <% end %>
       <% end %>

--- a/config/locales/en/assessed_claims.yml
+++ b/config/locales/en/assessed_claims.yml
@@ -14,6 +14,6 @@ en:
       caseworker_name: "Caseworker"
       status: "Status"
       status_list:
-        grant: "Granted"
+        granted: "Granted"
         part_grant: "Part granted"
-        reject: "Rejected"
+        rejected: "Rejected"

--- a/config/locales/en/events.yml
+++ b/config/locales/en/events.yml
@@ -3,7 +3,10 @@ en:
   event/new_version:
     title: New claim versions received
   event/decision:
-    title: Decision made to %{state} claim
+    title:
+      granted: Decision made to grant claim
+      part_grant: Decision made to part grant claim
+      rejected: Decision made to reject claim
   event/change_risk:
     title: Claim risk changed to %{risk} risk
   event/note:

--- a/config/locales/en/make_decisions.yml
+++ b/config/locales/en/make_decisions.yml
@@ -7,9 +7,9 @@ en:
       submit: Submit decision
     update:
       decision:
-        grant: You granted this claim <a class="govuk-link" href="%{url}">%{ref}</a>
+        granted: You granted this claim <a class="govuk-link" href="%{url}">%{ref}</a>
         part_grant: You part granted this claim <a class="govuk-link" href="%{url}">%{ref}</a>
-        reject: You rejected this claim <a class="govuk-link" href="%{url}">%{ref}</a>
+        rejected: You rejected this claim <a class="govuk-link" href="%{url}">%{ref}</a>
   helpers:
     legend:
       make_decision_form:
@@ -17,9 +17,9 @@ en:
     label:
       make_decision_form:
         state_options:
-          grant: Grant it
+          granted: Grant it
           part_grant: Part grant it
-          reject: Reject it
+          rejected: Reject it
         partial_comment: Explain your decision
         reject_comment: Explain your decision
     hint:

--- a/spec/controllers/make_decisions_controller_spec.rb
+++ b/spec/controllers/make_decisions_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe MakeDecisionsController do
   end
 
   context 'update' do
-    let(:decision) { instance_double(MakeDecisionForm, save: save, state: 'grant') }
+    let(:decision) { instance_double(MakeDecisionForm, save: save, state: 'granted') }
     let(:user) { instance_double(User) }
     let(:claim) { instance_double(Claim, id: SecureRandom.uuid) }
     let(:laa_reference_class) { instance_double(V1::LaaReference, laa_reference: 'AAA111') }
@@ -39,10 +39,10 @@ RSpec.describe MakeDecisionsController do
     it 'builds a decision object' do
       put :update, params: {
         claim_id: claim.id,
-        make_decision_form: { state: 'grant', partial_comment: nil, reject_comment: nil, id: claim.id }
+        make_decision_form: { state: 'granted', partial_comment: nil, reject_comment: nil, id: claim.id }
       }
       expect(MakeDecisionForm).to have_received(:new).with(
-        'state' => 'grant', 'partial_comment' => '', 'reject_comment' => '', 'id' => claim.id, 'current_user' => user
+        'state' => 'granted', 'partial_comment' => '', 'reject_comment' => '', 'id' => claim.id, 'current_user' => user
       )
     end
 
@@ -50,7 +50,7 @@ RSpec.describe MakeDecisionsController do
       it 'redirects to claim page' do
         put :update, params: {
           claim_id: claim.id,
-          make_decision_form: { state: 'grant', partial_comment: nil, reject_comment: nil, id: claim.id }
+          make_decision_form: { state: 'granted', partial_comment: nil, reject_comment: nil, id: claim.id }
         }
 
         expect(response).to redirect_to(assessed_claims_path)
@@ -67,7 +67,7 @@ RSpec.describe MakeDecisionsController do
         allow(controller).to receive(:render)
         put :update, params: {
           claim_id: claim.id,
-          make_decision_form: { state: 'grant', partial_comment: nil, reject_comment: nil, id: claim.id }
+          make_decision_form: { state: 'granted', partial_comment: nil, reject_comment: nil, id: claim.id }
         }
 
         expect(controller).to have_received(:render)

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -15,7 +15,7 @@ FactoryBot.define do
       details do
         {
           from: 'submitted',
-          to: 'grant'
+          to: 'granted'
         }
       end
     end
@@ -93,7 +93,7 @@ FactoryBot.define do
         {
           field: 'state',
           from: 'submitted',
-          to: 'grant',
+          to: 'granted',
           comment: 'grant it'
         }
       end

--- a/spec/forms/make_decision_form_spec.rb
+++ b/spec/forms/make_decision_form_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe MakeDecisionForm do
       end
     end
 
-    context 'when state is grant' do
-      let(:params) { { id: claim.id, state: 'grant' } }
+    context 'when state is granted' do
+      let(:params) { { id: claim.id, state: 'granted' } }
 
       it { expect(subject).to be_valid }
     end
@@ -47,9 +47,9 @@ RSpec.describe MakeDecisionForm do
       end
     end
 
-    context 'when state is reject' do
+    context 'when state is rejected' do
       context 'when reject_comment is blank' do
-        let(:params) { { id: claim.id, state: 'reject', reject_comment: nil } }
+        let(:params) { { id: claim.id, state: 'rejected', reject_comment: nil } }
 
         it 'is invalid' do
           expect(subject).not_to be_valid
@@ -58,7 +58,7 @@ RSpec.describe MakeDecisionForm do
       end
 
       context 'when reject_comment is set' do
-        let(:params) { { id: claim.id, state: 'reject', reject_comment: 'reject comment' } }
+        let(:params) { { id: claim.id, state: 'rejected', reject_comment: 'reject comment' } }
 
         it { expect(subject).to be_valid }
       end
@@ -126,8 +126,8 @@ RSpec.describe MakeDecisionForm do
   describe '#comment' do
     let(:params) { { state: state, partial_comment: 'part comment', reject_comment: 'reject comment' } }
 
-    context 'when state is grant' do
-      let(:state) { 'grant' }
+    context 'when state is granted' do
+      let(:state) { 'granted' }
 
       it 'ignores all comment fields' do
         expect(subject.comment).to be_nil
@@ -142,8 +142,8 @@ RSpec.describe MakeDecisionForm do
       end
     end
 
-    context 'when state is reject' do
-      let(:state) { 'reject' }
+    context 'when state is rejected' do
+      let(:state) { 'rejected' }
 
       it 'uses the reject_comment field' do
         expect(subject.comment).to eq('reject comment')

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -169,9 +169,9 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe '#accessed_colour' do
     it 'returns the case based on the state' do
-      expect(helper.accessed_colour('grant')).to eq('green')
+      expect(helper.accessed_colour('granted')).to eq('green')
       expect(helper.accessed_colour('part-grant')).to eq('blue')
-      expect(helper.accessed_colour('reject')).to eq('red')
+      expect(helper.accessed_colour('rejected')).to eq('red')
       expect(helper.accessed_colour('other')).to be_nil
     end
   end

--- a/spec/jobs/pull_latest_version_data_spec.rb
+++ b/spec/jobs/pull_latest_version_data_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe PullLatestVersionData do
           'secondary_user_id' => nil,
           'linked_type' => nil,
           'linked_id' => nil,
-          'details' => { 'to' => 'grant', 'from' => 'submitted', 'field' => 'state', 'comment' => nil },
+          'details' => { 'to' => 'granted', 'from' => 'submitted', 'field' => 'state', 'comment' => nil },
           'created_at' => '2023-10-02T14:41:45.136Z',
           'updated_at' => '2023-10-02T14:41:45.136Z',
           'public' => true
@@ -65,7 +65,7 @@ RSpec.describe PullLatestVersionData do
           secondary_user_id: nil,
           linked_type: nil,
           linked_id: nil,
-          details: { 'to' => 'grant', 'from' => 'submitted', 'field' => 'state', 'comment' => nil },
+          details: { 'to' => 'granted', 'from' => 'submitted', 'field' => 'state', 'comment' => nil },
           created_at: Time.parse('2023-10-02T14:41:45.136Z'),
           updated_at: Time.parse('2023-10-02T14:41:45.136Z'),
         )

--- a/spec/models/event/decision_spec.rb
+++ b/spec/models/event/decision_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Event::Decision do
   subject { described_class.build(claim:, previous_state:, comment:, current_user:) }
 
   let(:claim) { create(:claim, state:) }
-  let(:state) { 'grant' }
+  let(:state) { 'granted' }
   let(:current_user) { create(:caseworker) }
   let(:previous_state) { 'submitted' }
   let(:comment) { 'decison was made' }
@@ -18,7 +18,7 @@ RSpec.describe Event::Decision do
       details: {
         'field' => 'state',
         'from' => 'submitted',
-        'to' => 'grant',
+        'to' => 'granted',
         'comment' => 'decison was made'
       }
     )

--- a/spec/models/event/decision_spec.rb
+++ b/spec/models/event/decision_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Event::Decision do
   end
 
   context 'when rejected' do
-    let(:state) { 'reject' }
+    let(:state) { 'rejected' }
 
     it 'has a valid title' do
       expect(subject.title).to eq('Decision made to reject claim')

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Event do
         expect(event.as_json).to match(
           'claim_version' => 1,
           'created_at' => an_instance_of(String),
-          'details' => { 'from' => 'submitted', 'to' => 'grant' },
+          'details' => { 'from' => 'submitted', 'to' => 'granted' },
           'linked_id' => nil,
           'linked_type' => nil,
           'primary_user_id' => nil,

--- a/spec/services/notify_app_store/message_builder_spec.rb
+++ b/spec/services/notify_app_store/message_builder_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe NotifyAppStore::MessageBuilder do
   subject { described_class.new(claim:) }
 
   let(:claim) do
-    instance_double(Claim, id: SecureRandom.uuid, state: 'grant', risk: 'high', data: { 'version' => 'data' },
+    instance_double(Claim, id: SecureRandom.uuid, state: 'granted', risk: 'high', data: { 'version' => 'data' },
    events: events)
   end
   let(:tester) { double(:tester, process: true) }
@@ -22,7 +22,7 @@ RSpec.describe NotifyAppStore::MessageBuilder do
         { 'event' => 2 }
       ],
       application_id: claim.id,
-      application_state: 'grant',
+      application_state: 'granted',
       application_risk: 'high',
       json_schema_version: 1
     )

--- a/spec/view_models/base_view_model_spec.rb
+++ b/spec/view_models/base_view_model_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe BaseViewModel do
   let(:implementation_class) { V1::ClaimSummary }
   let(:claim) { instance_double(Claim, json_schema_version: 1, data: data, attributes: { state: }, events: event) }
   let(:event) { Event }
-  let(:state) { 'grant' }
+  let(:state) { 'granted' }
 
   describe '#build' do
     context 'for a single object' do
-      let(:data) { { 'laa_reference' => 'LA111', 'defendants' => [{ 'some' => 'data' }], 'state' => 'grant' } }
+      let(:data) { { 'laa_reference' => 'LA111', 'defendants' => [{ 'some' => 'data' }], 'state' => 'granted' } }
 
       it 'returns an instance with the correct attributes' do
         result = described_class.build(:assessed_claims, claim)
         expect(result).to have_attributes(
-          state: 'grant',
+          state: 'granted',
         )
       end
 

--- a/spec/view_models/v1/assessed_claims_spec.rb
+++ b/spec/view_models/v1/assessed_claims_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe V1::AssessedClaims, type: :view_model do
   let(:claim) { instance_double(Claim, id: 1, events: events) }
   let(:events) { double(where: double(order: [instance_double(Event, primary_user:)])) }
   let(:primary_user) { instance_double(User, display_name: 'Jim Bob') }
-  let(:state) { 'grant' }
+  let(:state) { 'granted' }
 
   describe '#main_defendant_name' do
     it 'returns the name of the main defendant' do
@@ -53,9 +53,9 @@ RSpec.describe V1::AssessedClaims, type: :view_model do
 
   describe '#status' do
     it 'returns the correct color for the given item' do
-      expect(subject.status('grant')).to eq({ colour: 'green', sort_value: 1, text: 'grant' })
+      expect(subject.status('granted')).to eq({ colour: 'green', sort_value: 1, text: 'granted' })
       expect(subject.status('part_grant')).to eq({ colour: 'blue', text: 'part_grant', sort_value: 2 })
-      expect(subject.status('reject')).to eq({ colour: 'red', text: 'reject', sort_value: 3 })
+      expect(subject.status('rejected')).to eq({ colour: 'red', text: 'rejected', sort_value: 3 })
       expect(subject.status('invalid')).to eq({ colour: 'grey', text: 'invalid', sort_value: 4 })
     end
   end
@@ -68,7 +68,7 @@ RSpec.describe V1::AssessedClaims, type: :view_model do
         'John Doe',
         { text: I18n.l(Time.zone.yesterday, format: '%-d %b %Y'), sort_value: Time.zone.yesterday.to_fs(:db) },
         'Jim Bob',
-        { colour: 'green', sort_value: 1, text: 'grant' }
+        { colour: 'green', sort_value: 1, text: 'granted' }
       ]
       expect(assessed_claims.table_fields).to eq(expected_fields)
     end


### PR DESCRIPTION
## Description of change

- Remove current version check for updating data

## Link to relevant ticket

[Caseworker App Failing to Update from App Store When Schema Version Not 1](https://dsdmoj.atlassian.net/browse/CRM457-730)

