### PR TITLE
Add additional check for uplifts to prevent nil coersion to Integer

### DIFF
--- a/app/forms/work_item_form.rb
+++ b/app/forms/work_item_form.rb
@@ -43,7 +43,7 @@ class WorkItemForm < BaseAdjustmentForm
   end
 
   def new_uplift
-    uplift == 'yes' ? 0 : item.provider_requested_uplift
+    uplift == 'yes' && !item.provider_requested_uplift.nil? ? 0 : item.provider_requested_uplift
   end
 
   def data_has_changed?


### PR DESCRIPTION
## Description of change

## Link to relevant ticket

[Incorrect Uplift Value Shown in Change Work Item Form When No Uplift](https://dsdmoj.atlassian.net/browse/CRM457-741)

[Extra context here](https://mojdt.slack.com/archives/C05212WRK5J/p1700823135194779)

