### PR TITLE
Add missing button to evidence and history screens

### DIFF
--- a/app/assets/stylesheets/custom/history-background.scss
+++ b/app/assets/stylesheets/custom/history-background.scss
@@ -1,4 +1,5 @@
 .history-input {
   background: govuk-colour("light-grey");
   padding: 30px 30px 0 30px;
+  margin-bottom: 30px;
 }

--- a/app/views/histories/show.html.erb
+++ b/app/views/histories/show.html.erb
@@ -38,12 +38,7 @@
       end %>
     <%= render "shared/pagination",  { pagy: pagy, item: t('.table_info_item') } %>
 
-  </div>
-</div>
-
-<% if claim.editable? %>
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full govuk-!-padding-right-0">
+    <% if claim.editable? %>
       <div class='history-input'>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-three-quarters govuk-!-padding-right-0">
@@ -54,6 +49,9 @@
           </div>
         </div>
       </div>
-    </div>
+    <% end %>
+
+    <%= render partial: 'shared/claim_button_group', locals: { claim: claim } %>
   </div>
-<% end %>
+</div>
+

--- a/app/views/supporting_evidences/show.html.erb
+++ b/app/views/supporting_evidences/show.html.erb
@@ -19,5 +19,6 @@
     <% unless @supporting_evidence.empty? %>
       <%= render "shared/pagination", { pagy: @pagy, item: t('.heading') } %>
     <% end %>
+    <%= render partial: 'shared/claim_button_group', locals: { claim: claim } %>
   </div>
 </div>


### PR DESCRIPTION
## Description of change
Add missing button from button of supporting evidence and history pages

## Link to relevant ticket

[CRM457-775](https://dsdmoj.atlassian.net/browse/CRM457-775)

<img width="641" alt="Screenshot 2023-12-11 at 12 32 25" src="https://github.com/ministryofjustice/laa-assess-non-standard-magistrate-fee/assets/63736/8fdc56a0-14fb-4931-b4b1-6ea16526ef79">
<img width="1047" alt="Screenshot 2023-12-11 at 12 32 31" src="https://github.com/ministryofjustice/laa-assess-non-standard-magistrate-fee/assets/63736/a522bf88-70e9-4de7-b5f5-ba0afbc0eb0d">



[CRM457-775]: https://dsdmoj.atlassian.net/browse/CRM457-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ