### PR TITLE
POC: expected JSON format for VAT

### DIFF
--- a/db/seeds/de2d6169-c769-4571-b3f2-220bcf8c3ce9/version.json
+++ b/db/seeds/de2d6169-c769-4571-b3f2-220bcf8c3ce9/version.json
@@ -6,8 +6,6 @@
   "state": "submitted",
   "data": {
     "id": "de2d6169-c769-4571-b3f2-220bcf8c3ce9",
-    "submitted_total": 100,
-    "adjusted_total": 40,
     "ufn": "121111/001",
     "plea_category": {
       "value": "category_2",
@@ -93,7 +91,8 @@
       "previous_id": null,
       "account_number": "121234",
       "address_line_1": "Suite 3",
-      "address_line_2": "5 Princess Road"
+      "address_line_2": "5 Princess Road",
+      "vat_registered": "yes"
     },
     "matter_type": {
       "value": "1",
@@ -206,7 +205,12 @@
     "remitted_to_magistrate_date": "2022-12-12",
     "reason_for_claim_other_details": "",
     "representation_order_withdrawn_date": null,
-    "supporting_evidences": []
+    "supporting_evidences": [],
+    "submitted_total": 1000.0,
+    "submitted_total_inc_vat": 1200.0,
+    "adjusted_total": 1000.0,
+    "adjusted_total_inc_vat": 1200.0,
+    "vat_rate": 0.2
   },
   "created_at": "2023-09-18T14:12:50.825Z",
   "updated_at": "2023-09-18T14:12:50.825Z"

--- a/db/seeds/f1ba0909-020f-4373-a167-9100923bdcaa/version.json
+++ b/db/seeds/f1ba0909-020f-4373-a167-9100923bdcaa/version.json
@@ -117,7 +117,8 @@
             "previous_id": null,
             "account_number": "hh",
             "address_line_1": "hh",
-            "address_line_2": "hh"
+            "address_line_2": "hh",
+            "vat_registered": "no"
         },
         "matter_type": {
             "value": "3",
@@ -420,5 +421,10 @@
         ]
     },
     "created_at": "2023-09-18T14:13:29.025Z",
-    "updated_at": "2023-09-18T14:13:29.025Z"
+    "updated_at": "2023-09-18T14:13:29.025Z",
+    "submitted_total": 1000.0,
+    "submitted_total_inc_vat": 1050.0,
+    "adjusted_total": 1000.0,
+    "adjusted_total_inc_vat": 1050.0,
+    "vat_rate": 0.0
 }


### PR DESCRIPTION
## Description of change
This is a suggestion on how VAT would be added to the JSON document

## Link to relevant ticket
N/A

## Notes for reviewer

* `vat_rate` is stored on the top level of the JSON as this will make it easier to access
* `submitted_total_inc_vat` and `adjusted_total_inc_vat` are still populated when `vat_rate` is 0 (`vat_registered` is no)
* vat can still exist when `vat_registered` is no (from disbursements)