### PR TITLE
Bump bundler 2.4.10 --> 2.4.22

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -541,4 +541,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.10
+   2.4.22


### PR DESCRIPTION
## Description of change
Bump bundler 2.4.10 --> 2.4.22

latest bundler version - [changelog](https://github.com/rubygems/rubygems/blob/master/bundler/CHANGELOG.md)