### PR TITLE
Chore: handle param comparison deprecation

### DIFF
--- a/spec/controllers/change_risks_controller_spec.rb
+++ b/spec/controllers/change_risks_controller_spec.rb
@@ -40,10 +40,12 @@ RSpec.describe ChangeRisksController, type: :controller do
         claim_id: claim.id,
         change_risk_form: { risk_level: 'low', explanation: nil, id: claim.id }
       }
-      # expect(risk).to have_received(:risk_level)
-      expect(ChangeRiskForm).to have_received(:new).with(
-        'risk_level' => 'low', 'explanation' => '', 'id' => claim.id, 'current_user' => user
-      )
+
+      expected_params = ActionController::Parameters.new(risk_level: 'low',
+                                                         explanation: '',
+                                                         id: claim.id,
+                                                         current_user: user).permit!
+      expect(ChangeRiskForm).to have_received(:new).with(expected_params)
     end
 
     context 'when decision has an erorr being updated' do

--- a/spec/controllers/histories_controller_spec.rb
+++ b/spec/controllers/histories_controller_spec.rb
@@ -45,9 +45,8 @@ RSpec.describe HistoriesController do
         claim_note_form: { note: 'new note', id: claim.id }
       }
 
-      expect(ClaimNoteForm).to have_received(:new).with(
-        'note' => 'new note', 'id' => claim.id, 'current_user' => user
-      )
+      expected_params = ActionController::Parameters.new(note: 'new note', id: claim.id, current_user: user).permit!
+      expect(ClaimNoteForm).to have_received(:new).with(expected_params)
     end
 
     context 'when decision has an erorr being updated' do


### PR DESCRIPTION
## Description of change
Chore: handle param comparison deprecation

Fix the deprecation warnings from couple of tests

```shell
DEPRECATION WARNING: Comparing equality between `ActionController::Parameters` and a `Hash` is deprecated and will be removed in Rails 7.2. Please only do comparisons between instances of `ActionController::Parameters`. If you need to compare to a hash, first convert it using `ActionController::Parameters#new`. To disable the deprecated behavior set `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false`. (called from block (3 levels) in <top (required)> at .../spec/controllers/change_risks_controller_spec.rb:44)
DEPRECATION WARNING: Comparing equality between `ActionController::Parameters` and a `Hash` is deprecated and will be removed in Rails 7.2. Please only do comparisons between instances of `ActionController::Parameters`. If you need to compare to a hash, first convert it using `ActionController::Parameters#new`. To disable the deprecated behavior set `Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false`. (called from block (3 levels) in <top (required)> at ..../spec/controllers/histories_controller_spec.rb:48)
```
