### PR TITLE
CRM457-866: bump rails defaults 7.0 to 7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'sentry-rails'
 gem 'sentry-ruby'
 
 group :development, :test do
-  gem 'debug'
+  gem 'debug', platforms: %i[mri windows]
   gem 'dotenv-rails'
   gem 'erb_lint', require: false
   gem 'pry'

--- a/app/controllers/users/dev_auth_controller.rb
+++ b/app/controllers/users/dev_auth_controller.rb
@@ -3,7 +3,7 @@ module Users
     layout 'external'
 
     def new
-      raise ActionController::RoutingError unless FeatureFlags.dev_auth.enabled?
+      raise ActionController::RoutingError, 'dev authentication not available' unless FeatureFlags.dev_auth.enabled?
 
       @emails = User.order(last_auth_at: :desc).pluck(:email) << OmniAuth::Strategies::DevAuth::NO_AUTH_EMAIL
     end

--- a/app/helpers/form_builder_helper.rb
+++ b/app/helpers/form_builder_helper.rb
@@ -1,4 +1,4 @@
-require_relative '../../lib/govuk_design_system_formbuilder/elements/period'
+require Rails.root.join('lib/govuk_design_system_formbuilder/elements/period')
 
 module FormBuilderHelper
   # :nocov:

--- a/app/models/concerns/auth_updateable.rb
+++ b/app/models/concerns/auth_updateable.rb
@@ -4,7 +4,7 @@
 # Activates the user by setting the "auth_subject_id" and "first_auth_at"
 # if the user is "pending_activation?".
 
-require 'warden_hooks/auth_updateable'
+require Rails.root.join('app/lib/warden_hooks/auth_updateable')
 
 module AuthUpdateable
   extend ActiveSupport::Concern

--- a/app/models/concerns/reauthable.rb
+++ b/app/models/concerns/reauthable.rb
@@ -2,7 +2,7 @@
 # authentications regardless of user activity.
 #
 
-require 'warden_hooks/reauthable'
+require Rails.root.join('app/lib/warden_hooks/reauthable')
 
 module Reauthable
   extend ActiveSupport::Concern

--- a/bin/setup
+++ b/bin/setup
@@ -7,7 +7,7 @@ require 'fileutils'
 APP_ROOT = File.expand_path('..', __dir__)
 
 def system!(*args)
-  system(*args) || abort("\n== Command #{args} failed ==")
+  system(*args, exception: true)
 end
 
 FileUtils.chdir APP_ROOT do

--- a/config/application.rb
+++ b/config/application.rb
@@ -28,7 +28,11 @@ module LaaAssessNonStandardMagistrateFee
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w(assets tasks))
+    #
+    # NOTE: govuk_design_system_formbuilder monkey patch in lib folder is not
+    # autoloaded because it the gem itself uses a non-standard/convention filename
+    # to classname pattern.
+    config.autoload_lib(ignore: %w(assets tasks govuk_design_system_formbuilder))
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,7 +23,7 @@ Bundler.require(*Rails.groups)
 module LaaAssessNonStandardMagistrateFee
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 7.0
+    config.load_defaults 7.1
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,11 @@ module LaaAssessNonStandardMagistrateFee
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
+    # Please, add to the `ignore` list any other `lib` subdirectories that do
+    # not contain `.rb` files, or that should not be reloaded or eager loaded.
+    # Common ones are `templates`, `generators`, or `middleware`, for example.
+    config.autoload_lib(ignore: %w(assets tasks))
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,7 +8,7 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.enable_reloading = true
 
   # Do not eager load code on boot.
   config.eager_load = false
@@ -18,6 +18,9 @@ Rails.application.configure do
 
   # Enable server timing
   config.server_timing = true
+
+  # Highlight code that enqueued background job in logs.
+  config.active_job.verbose_enqueue_logs = true
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
@@ -72,7 +75,10 @@ Rails.application.configure do
 
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
-  #
+
+  # Raise error when a before_action's only/except options reference missing actions
+  config.action_controller.raise_on_missing_callback_actions = true
+
   config.logstasher.enabled = true
   config.logstasher.logger_path = 'log/logstasher_development.log'
   config.logstasher.log_level = Logger::INFO

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,9 +28,11 @@ Rails.application.configure do
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
-  # Whether to fallback to assets pipeline if a precompiled asset is missed. This
-  # should be false in production
-  config.assets.compile = false
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  # NOTE: this should be set to false. Relying on the fallback implies some assets are
+  # not being compiled until the first request to the server. The Dockerfiles'
+  # `rails assets:precompile` command should compile all assets.
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -6,7 +6,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Code is not reloaded between requests.
-  config.cache_classes = true
+  config.enable_reloading = false
 
   # Eager load code on boot. This eager loads most of Rails and
   # your application in memory, allowing both threaded web servers
@@ -15,15 +15,14 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
 
-  # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
-  # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
+  # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
+  # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
   # config.require_master_key = true
 
-  # Disable serving static files from the `/public` folder by default since
-  # Apache or NGINX already handles this.
+  # Enable static file serving from the `/public` folder (turn off if using NGINX/Apache for it).
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress CSS using a preprocessor.
@@ -50,9 +49,16 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Include generic and useful information about system operation, but avoid logging too much
-  # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    config.logger = ActiveSupport::Logger.new(STDOUT)
+                      .tap  { |logger| logger.formatter = ::Logger::Formatter.new }
+                      .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
+  end
+
+  # Info include generic and useful information about system operation, but avoids logging too much
+  # information to avoid inadvertent exposure of personally identifiable information (PII). If you
+  # want to log everything, set the level to "debug".
+  config.log_level = ENV.fetch("RAILS_LOG_LEVEL", "info")
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
@@ -61,7 +67,7 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
-  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_adapter = :resque
   # config.active_job.queue_name_prefix = "laa_assess_non_standard_magistrate_fee_production"
 
   config.action_mailer.perform_caching = false
@@ -78,21 +84,16 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require "syslog/logger"
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new "app-name")
-
-  if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new($stdout)
-    logger.formatter = config.log_formatter
-    config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  end
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Enable DNS rebinding protection and other `Host` header attacks.
+  # config.hosts = [
+  #   "example.com",     # Allow requests from example.com
+  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
+  # ]
+  # Skip DNS rebinding protection for the default health check endpoint.
+  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 
   config.logstasher.enabled = true
   config.logstasher.logger_path = 'log/logstasher.log'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,8 +28,9 @@ Rails.application.configure do
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
+  # Whether to fallback to assets pipeline if a precompiled asset is missed. This
+  # should be false in production
+  config.assets.compile = false
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
@@ -48,6 +49,10 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
+
+  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
+  # config.assume_ssl = true
 
   if ENV["RAILS_LOG_TO_STDOUT"].present?
     config.logger = ActiveSupport::Logger.new(STDOUT)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,12 +10,13 @@ require 'active_support/core_ext/integer/time'
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # Turn false under Spring and add config.action_view.cache_template_loading = true.
-  config.cache_classes = true
+  # While tests run files are not watched, reloading is not necessary.
+  config.enable_reloading = false
 
-  # Eager loading loads your whole application. When running a single test locally,
-  # this probably isn't necessary. It's a good idea to do in a continuous integration
-  # system, or in some way before deploying your code.
+  # Eager loading loads your entire application. When running a single test locally,
+  # this is usually not necessary, and can slow down your test suite. However, it's
+  # recommended that you enable it in continuous integration systems to ensure eager
+  # loading is working properly before deploying your code.
   config.eager_load = ENV['CI'].present?
 
   # Configure public file server for tests with Cache-Control for performance.
@@ -25,12 +26,12 @@ Rails.application.configure do
   }
 
   # Show full error reports and disable caching.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = :all
+  config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
@@ -62,6 +63,9 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  # Raise error when a before_action's only/except options reference missing actions
+  config.action_controller.raise_on_missing_callback_actions = true
 
   config.logstasher.enabled = true
   config.logstasher.logger_path = 'log/logstasher_development.log'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -25,12 +25,18 @@ Rails.application.configure do
     'Cache-Control' => "public, max-age=#{1.hour.to_i}"
   }
 
+  # Compress CSS using a preprocessor.
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
   # Show full error reports and disable caching.
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = false
   config.cache_store = :null_store
 
-  # Raise exceptions instead of rendering exception templates.
+  # Render exception templates for rescuable exceptions and raise for other exceptions.
   config.action_dispatch.show_exceptions = :rescuable
 
   # Disable request forgery protection in test environment.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,9 +28,6 @@ Rails.application.configure do
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
-  # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
-
   # Show full error reports and disable caching.
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = false

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -17,9 +17,9 @@
 #     # policy.report_uri "/csp-violation-report-endpoint"
 #   end
 #
-#   # Generate session nonces for permitted importmap and inline scripts
+#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
 #   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src)
+#   config.content_security_policy_nonce_directives = %w(script-src style-src)
 #
 #   # Report violations without enforcing the policy.
 #   # config.content_security_policy_report_only = true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,6 +1,6 @@
-require 'host_env'
-require 'feature_flags'
-require 'omni_auth/strategies/dev_auth'
+require Rails.root.join('app/lib/host_env')
+require Rails.root.join('app/lib/feature_flags')
+require Rails.root.join('app/lib/omni_auth/strategies/dev_auth')
 
 Devise.setup do |config|
   require 'devise/orm/active_record'

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -2,9 +2,9 @@
 
 # Be sure to restart your server when you modify this file.
 
-# Configure parameters to be filtered from the log file. Use this to limit dissemination of
-# sensitive information. See the ActiveSupport::ParameterFilter documentation for supported
-# notations and behaviors.
+# Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
+# Use this to limit dissemination of sensitive information.
+# See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
 Rails.application.config.filter_parameters += %i[
   passw secret token _key crypt salt certificate otp ssn
 ]

--- a/config/initializers/form_builder.rb
+++ b/config/initializers/form_builder.rb
@@ -1,4 +1,4 @@
-require_relative '../../app/helpers/form_builder_helper'
+require Rails.root.join('app/helpers/form_builder_helper')
 
 ActionView::Base.default_form_builder = GOVUKDesignSystemFormBuilder::FormBuilder
 

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 # Define an application-wide HTTP permissions policy. For further
-# information see https://developers.google.com/web/updates/2018/06/feature-policy
-#
-# Rails.application.config.permissions_policy do |f|
-#   f.camera      :none
-#   f.gyroscope   :none
-#   f.microphone  :none
-#   f.usb         :none
-#   f.fullscreen  :self
-#   f.payment     :self, "https://secure.example.com"
+# information see: https://developers.google.com/web/updates/2018/06/feature-policy
+
+# Rails.application.config.permissions_policy do |policy|
+#   policy.camera      :none
+#   policy.gyroscope   :none
+#   policy.microphone  :none
+#   policy.usb         :none
+#   policy.fullscreen  :self
+#   policy.payment     :self, "https://secure.example.com"
 # end

--- a/config/locales/en/claims.yml
+++ b/config/locales/en/claims.yml
@@ -46,7 +46,12 @@ en:
   adjustments:
     show:
       check_totals: View core costs
+      core_cost: Core costs
+      disbursements: Disbursements
       items: Items
+      letters_and_calls: Letters and calls
+      review_and_adjust: Adjustments
       total_time: Time total
       total_cost: Cost total
       total: Total
+      work_items: Work items

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -26,20 +26,5 @@ environment ENV.fetch('RAILS_ENV', 'development')
 # Specifies the `pidfile` that Puma will use.
 pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 
-# Specifies the number of `workers` to boot in clustered mode.
-# Workers are forked web server processes. If using threads and workers together
-# the concurrency of the application would be max `threads` * `workers`.
-# Workers do not work on JRuby or Windows (both of which do not support
-# processes).
-#
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
-
-# Use the `preload_app!` method when specifying a `workers` number.
-# This directive tells Puma to first boot the application and load code
-# before forking the application. This takes advantage of Copy On Write
-# process behavior so workers use less memory.
-#
-# preload_app!
-
 # Allow puma to be restarted by `bin/rails restart` command.
 plugin :tmp_restart

--- a/spec/system/authenticating/dev_auth_spec.rb
+++ b/spec/system/authenticating/dev_auth_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe 'Authenticating with the DevAuth strategy' do
     it 'raises an error' do
       visit '/dev_auth'
 
-      expect(page).to have_http_status(:internal_server_error)
+      expect(page).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/zeitwerk_spec.rb
+++ b/spec/zeitwerk_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe 'Zeitwerk compliance' do
+  it 'eager loads all files without errors' do
+    expect { Rails.application.eager_load! }.not_to raise_error
+  end
+end
+# rubocop:enable RSpec/DescribeClass


### PR DESCRIPTION
## Description of change
Bump to use rails 7.1 defaults.

Keep upto date and so we can safely move to further rails bumps, such as 7.2

## Link to relevant ticket

[CRM457-866](https://dsdmoj.atlassian.net/browse/CRM457-866)

## Notes for reviewer
Will need UATing manually

[CRM457-866]: https://dsdmoj.atlassian.net/browse/CRM457-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ