### PR TITLE
Remove postinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "govuk-frontend": "^5.0.0"
   },
   "scripts": {
-    "postinstall": "bin/importmap pin govuk-frontend@5.0.0",
     "unit-test": "jest"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description of change
Remove postinstall script

This results in unexpected file changes when running yarn install

- config/importmap.rb
```sh
-pin "govuk-frontend", to: "https://ga.jspm.io/npm:govuk-frontend@5.0.0/dist/govuk/all.mjs"
+pin "govuk-frontend" # @5.0.0
```

- vendor/javascript/govuk-frontend.js (whole file added)

`config/importmap.rb` already pins as needed so postinstall is not required
I believe.

## Notes for reviewer
running yarn install locall should not result in file changes on this branch
