### PR TITLE
Fix browser tools issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2.1
 # ------------------
 orbs:
   ruby: circleci/ruby@2.0.1
-  browser-tools: circleci/browser-tools@1.4.5
+  browser-tools: circleci/browser-tools@1.4.7
   snyk: snyk/snyk@1.1.2
   aws-cli: circleci/aws-cli@4.0.0
   aws-ecr: circleci/aws-ecr@8.2.1
@@ -252,7 +252,11 @@ jobs:
       - install-gems
       - install-compile-assets
       - *attach-tmp-workspace
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          replace-existing-chrome: true
+          install-firefox: false
+          install-geckodriver: false
+          install-chromedriver: false
       - rspec
 
   upload-test-coverage:


### PR DESCRIPTION
Fix browser tools issue


Chrome not installing with error:
```
chrome version major is 116
Installed version of Google Chrome is 116.0.5845.140
500
116.0.5845.140 will be installed
curl: (22) The requested URL returned error: 500
```

expected behaviour:
```
Chrome version major is 116
Installed version of Google Chrome is 116.0.5845.140
404
Matching Chrome Driver Version 404'd, falling back to first matching major version.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   864  100   864    0     0   8617      0 --:--:-- --:--:-- --:--:--  8640
New ChromeDriver version to be installed: 116.0.5845.96
116.0.5845.96 will be installed
^@^@ChromeDriver 116.0.5845.96 (1a391816688002153ef791ffe60d9e899a71a037-refs/branch-heads/5845@{#1382}) has been installed to /usr/local/bin/chromedriver
````
